### PR TITLE
Add /reset command for hard resetting projects to origin

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -82,6 +82,7 @@ src/
 | `/update` | Pull all clean projects (skips dirty/active) |
 | `/selfupdate` | Pull and rebuild Miranda |
 | `/restart` | Graceful restart |
+| `/reset <project>` | Hard reset project to origin (with confirmation) |
 | `/tasks <project>` | List tasks for a project |
 | `/newproject <repo>` | Clone GitHub repo and init ba/sg |
 | `/mouse <task>` | Start mouse skill for task |


### PR DESCRIPTION
## Completed Tasks
- kv-6ced: Add /reset command to hard reset project to origin

## Summary
Adds `/reset <project>` command that performs a hard reset of a project to its origin branch:

- Detects default branch (main or master) from origin
- Shows confirmation keyboard with target branch before executing
- Blocks reset if active sessions exist in the project
- Performs: `git fetch origin`, `git checkout <branch>`, `git reset --hard origin/<branch>`, `git clean -fd`
- Reports previous and new HEAD commit after reset

**Safety features:**
- Confirmation required via inline keyboard
- Active session check prevents data loss during mouse/drummer runs
- Re-validates project and sessions at confirmation time (race condition handling)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added /reset command for restoring projects to origin.
  * Confirmation prompt shows target branch and requires explicit approval.
  * Reset blocked while active sessions exist; users must stop sessions first.
  * Clear cancellation and success/failure messaging, including reported branch/head changes.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->