### PR TITLE
Rename /update command to /pull

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -79,7 +79,7 @@ src/
 | Command | Action |
 |---------|--------|
 | `/projects` | List projects on server with task counts |
-| `/update` | Pull all clean projects (skips dirty/active) |
+| `/pull` | Pull all clean projects (skips dirty/active) |
 | `/selfupdate` | Pull and rebuild Miranda |
 | `/restart` | Graceful restart |
 | `/reset <project>` | Hard reset project to origin (with confirmation) |

--- a/src/bot/commands.ts
+++ b/src/bot/commands.ts
@@ -164,7 +164,7 @@ let shutdownFn: ShutdownFn | undefined;
  * - /drummer <project> - Run batch merge for a project
  * - /notes <project> <pr-number> - Address PR feedback
  * - /newproject <repo> - Clone repo and init ba/sg/wm
- * - /update - Pull all clean projects
+ * - /pull - Pull all clean projects
  * - /selfupdate - Pull and rebuild Miranda
  * - /restart - Graceful restart
  * - /logs, /ssh - Stubs for future implementation
@@ -184,7 +184,7 @@ export function registerCommands(bot: Bot<Context>, shutdown: ShutdownFn): void 
   bot.command("drummer", handleDrummer);
   bot.command("notes", handleNotes);
   bot.command("newproject", handleNewProject);
-  bot.command("update", handleUpdate);
+  bot.command("pull", handlePull);
   bot.command("selfupdate", handleSelfUpdate);
   bot.command("restart", handleRestart);
   bot.command("reset", handleReset);
@@ -204,7 +204,7 @@ I give voice to the Primer. Commands:
 /projects - List projects with tasks
 /tasks <project> - List tasks for a project
 /newproject <repo> - Clone and init new project
-/update - Pull all clean projects
+/pull - Pull all clean projects
 /selfupdate - Pull and rebuild Miranda
 /restart - Graceful restart
 /reset <project> - Hard reset project to origin
@@ -842,12 +842,12 @@ Addressing human feedback...`,
   }
 }
 
-async function handleUpdate(ctx: Context): Promise<void> {
-  await ctx.reply("Updating projects...");
+async function handlePull(ctx: Context): Promise<void> {
+  await ctx.reply("Pulling projects...");
 
   const projects = await scanProjects();
   if (projects.length === 0) {
-    await ctx.reply("*Update*\n\n_No projects found_", { parse_mode: "Markdown" });
+    await ctx.reply("*Pull*\n\n_No projects found_", { parse_mode: "Markdown" });
     return;
   }
 
@@ -890,7 +890,7 @@ async function handleUpdate(ctx: Context): Promise<void> {
   }
 
   // Build response message grouped by status
-  const lines: string[] = ["*Update Results*", ""];
+  const lines: string[] = ["*Pull Results*", ""];
 
   const updated = results.filter((r) => r.status === "updated");
   if (updated.length > 0) {


### PR DESCRIPTION
## Completed Tasks
- kv-4gh3: Rename /update command to /pull

## Summary
Renamed the `/update` command to `/pull` for better alignment with the underlying git operation. All references updated including:
- Command registration
- Help text (/start message)
- Function name (handleUpdate → handlePull)
- User-facing messages
- CLAUDE.md documentation

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated command reference and help text from `/update` to `/pull`.

* **Refactor**
  * Renamed the update command to pull and updated its registration.

* **Bug Fixes**
  * Pull now skips active tasks and checks repo freshness before running, with result messages updated to reflect “Pull.”

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->