### PR TITLE
feat(ohtask): support multiple GitHub issues in single command

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -80,7 +80,7 @@ src/
 
 | Command | Action |
 |---------|--------|
-| `/ohtask <project> <issue> [branch]` | Start oh-task skill for GitHub issue |
+| `/ohtask <project> <issue>... [--base branch]` | Start oh-task skill for GitHub issue(s) |
 | `/ohmerge <project>` | Batch merge GitHub issue PRs (oh-merge label) |
 | `/ohnotes <project> <pr>` | Address GitHub issue PR feedback |
 


### PR DESCRIPTION
Closes #62

## Summary
- Allow `/ohtask` to accept multiple issue numbers, spinning up a session for each
- Project is pulled once before spawning all sessions (efficient)
- Existing sessions are skipped with feedback rather than failing the whole command
- Supports `--base branch` flag and legacy trailing branch syntax for backward compatibility

## Usage

```
/ohtask <project> <issue>... [--base branch]

Examples:
  /ohtask miranda 42
  /ohtask miranda 42 43 44  
  /ohtask miranda 42 --base feature-branch
  /ohtask miranda 42 43 --base feature-branch
```

## Test plan
- [ ] Test single issue: `/ohtask miranda 1`
- [ ] Test multiple issues: `/ohtask miranda 1 2 3`
- [ ] Test with `--base`: `/ohtask miranda 1 2 --base feature`
- [ ] Test legacy syntax: `/ohtask miranda 1 feature-branch`
- [ ] Test existing session skip behavior
- [ ] Verify project pulled only once

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * /ohtask command now supports processing multiple issue numbers in a single command, replacing the single-issue limitation.
  * Added optional --base branch flag for specifying the target branch when starting multiple issues.
  * Enhanced feedback mechanism showing per-issue status, clearly indicating successful starts and errors.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->