### PR TITLE
Add HTTP API server with session and project endpoints

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,3 +6,4 @@ OMP_CLI_PATH=/home/user/.bun/bin/omp      # Path to oh-my-pi CLI binary
 # Optional
 PROJECTS_DIR=~/projects                   # Directory to scan for projects (default: ~/projects)
 MIRANDA_HOME=~/miranda                    # Override Miranda project root (default: derived from module location)
+MIRANDA_PORT=3847                        # HTTP API server port (default: 3847)

--- a/public/index.html
+++ b/public/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Miranda Control Center</title>
+</head>
+<body>
+  <h1>Miranda Control Center</h1>
+  <p>Mini App coming soon.</p>
+</body>
+</html>

--- a/src/api/routes.ts
+++ b/src/api/routes.ts
@@ -1,0 +1,142 @@
+import type { IncomingMessage, ServerResponse } from "node:http";
+import { getAllSessions, getSession, deleteSession } from "../state/sessions.js";
+import { scanProjects } from "../projects/scanner.js";
+import { stopSession } from "../bot/commands.js";
+
+/**
+ * Format elapsed time since a date as a human-readable string.
+ */
+function formatElapsed(startedAt: Date): string {
+  const elapsed = Date.now() - startedAt.getTime();
+  const minutes = Math.floor(elapsed / 60000);
+  if (minutes < 60) {
+    return `${minutes}m`;
+  }
+  const hours = Math.floor(minutes / 60);
+  const remainingMinutes = minutes % 60;
+  return `${hours}h ${remainingMinutes}m`;
+}
+
+/**
+ * Send a JSON response.
+ */
+function json(res: ServerResponse, status: number, body: unknown): void {
+  const payload = JSON.stringify(body);
+  res.writeHead(status, {
+    "Content-Type": "application/json",
+    "Access-Control-Allow-Origin": "*",
+    "Access-Control-Allow-Methods": "GET, POST, OPTIONS",
+    "Access-Control-Allow-Headers": "Content-Type",
+  });
+  res.end(payload);
+}
+
+
+/**
+ * GET /api/sessions — All sessions with status, elapsed time, skill type.
+ */
+export function handleGetSessions(_req: IncomingMessage, res: ServerResponse): void {
+  const sessions = getAllSessions();
+  const result = sessions.map((s) => ({
+    taskId: s.taskId,
+    sessionId: s.sessionId,
+    skill: s.skill,
+    status: s.status,
+    startedAt: s.startedAt.toISOString(),
+    elapsed: formatElapsed(s.startedAt),
+    pendingQuestion: s.pendingQuestion
+      ? {
+          messageId: s.pendingQuestion.messageId,
+          questions: s.pendingQuestion.questions.map((q) => q.question),
+          receivedAt: s.pendingQuestion.receivedAt.toISOString(),
+        }
+      : null,
+  }));
+  json(res, 200, { sessions: result });
+}
+
+/**
+ * GET /api/projects — All projects from PROJECTS_DIR with task counts.
+ */
+export async function handleGetProjects(_req: IncomingMessage, res: ServerResponse): Promise<void> {
+  try {
+    const projects = await scanProjects();
+    const result = projects.map((p) => ({
+      name: p.name,
+      path: p.path,
+      openCount: p.openCount,
+      inProgressCount: p.inProgressCount,
+    }));
+    json(res, 200, { projects: result });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    json(res, 500, { error: message });
+  }
+}
+
+/**
+ * POST /api/sessions/:id/stop — Stop a session by taskId.
+ */
+export async function handleStopSession(
+  _req: IncomingMessage,
+  res: ServerResponse,
+  taskId: string
+): Promise<void> {
+  const session = getSession(taskId);
+  if (!session) {
+    json(res, 404, { error: "Session not found" });
+    return;
+  }
+
+  try {
+    const graceful = await stopSession(session.sessionId);
+    deleteSession(taskId);
+    const method = graceful ? "stopped" : "killed";
+    json(res, 200, { taskId, method });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    json(res, 500, { error: message });
+  }
+}
+
+/**
+ * Route an API request to the appropriate handler.
+ * Returns true if a route matched, false otherwise.
+ */
+export async function routeApi(
+  req: IncomingMessage,
+  res: ServerResponse,
+  pathname: string
+): Promise<boolean> {
+  const method = req.method ?? "GET";
+
+  // Handle CORS preflight
+  if (method === "OPTIONS") {
+    res.writeHead(204, {
+      "Access-Control-Allow-Origin": "*",
+      "Access-Control-Allow-Methods": "GET, POST, OPTIONS",
+      "Access-Control-Allow-Headers": "Content-Type",
+    });
+    res.end();
+    return true;
+  }
+
+  if (pathname === "/api/sessions" && method === "GET") {
+    handleGetSessions(req, res);
+    return true;
+  }
+
+  if (pathname === "/api/projects" && method === "GET") {
+    await handleGetProjects(req, res);
+    return true;
+  }
+
+  // POST /api/sessions/:id/stop
+  const stopMatch = pathname.match(/^\/api\/sessions\/([^/]+)\/stop$/);
+  if (stopMatch && method === "POST") {
+    await handleStopSession(req, res, decodeURIComponent(stopMatch[1]));
+    return true;
+  }
+
+  return false;
+}

--- a/src/api/server.ts
+++ b/src/api/server.ts
@@ -1,0 +1,139 @@
+import { createServer, type Server, type IncomingMessage, type ServerResponse } from "node:http";
+import { createReadStream, existsSync, statSync } from "node:fs";
+import { join, extname, resolve } from "node:path";
+import { config } from "../config.js";
+import { routeApi } from "./routes.js";
+
+/**
+ * Content-Type map for static file serving.
+ */
+const CONTENT_TYPES: Record<string, string> = {
+  ".html": "text/html; charset=utf-8",
+  ".js": "application/javascript; charset=utf-8",
+  ".css": "text/css; charset=utf-8",
+  ".json": "application/json; charset=utf-8",
+  ".png": "image/png",
+  ".jpg": "image/jpeg",
+  ".jpeg": "image/jpeg",
+  ".svg": "image/svg+xml",
+  ".ico": "image/x-icon",
+};
+
+/**
+ * Resolve the public directory path.
+ * Uses config.mirandaHome to find the public/ directory
+ * relative to the project root.
+ */
+function getPublicDir(): string {
+  return join(config.mirandaHome, "public");
+}
+
+/**
+ * Serve a static file from the public/ directory.
+ * Returns true if a file was served, false otherwise.
+ */
+function serveStatic(req: IncomingMessage, res: ServerResponse, pathname: string): boolean {
+  const publicDir = getPublicDir();
+
+  // Default to index.html for root
+  let filePath = pathname === "/" ? "/index.html" : pathname;
+
+  // Resolve and verify path stays within public directory
+  const resolved = resolve(publicDir, filePath.slice(1));
+  if (!resolved.startsWith(resolve(publicDir))) {
+    // Path traversal attempt
+    return false;
+  }
+
+  if (!existsSync(resolved)) {
+    return false;
+  }
+
+  const stat = statSync(resolved);
+  if (!stat.isFile()) {
+    return false;
+  }
+
+  const ext = extname(resolved).toLowerCase();
+  const contentType = CONTENT_TYPES[ext] ?? "application/octet-stream";
+
+  res.writeHead(200, {
+    "Content-Type": contentType,
+    "Content-Length": stat.size,
+    "Access-Control-Allow-Origin": "*",
+  });
+  createReadStream(resolved).pipe(res);
+  return true;
+}
+
+/**
+ * Main request handler.
+ */
+async function handleRequest(req: IncomingMessage, res: ServerResponse): Promise<void> {
+  const url = new URL(req.url ?? "/", `http://${req.headers.host ?? "localhost"}`);
+  const pathname = url.pathname;
+
+  try {
+    // Try API routes first
+    const handled = await routeApi(req, res, pathname);
+    if (handled) return;
+
+    // Try static files
+    if (serveStatic(req, res, pathname)) return;
+
+    // 404
+    res.writeHead(404, { "Content-Type": "application/json" });
+    res.end(JSON.stringify({ error: "Not found" }));
+  } catch (error) {
+    console.error("HTTP request error:", error);
+    if (!res.headersSent) {
+      res.writeHead(500, { "Content-Type": "application/json" });
+      res.end(JSON.stringify({ error: "Internal server error" }));
+    }
+  }
+}
+
+let server: Server | null = null;
+
+/**
+ * Start the HTTP API server.
+ */
+export function startApiServer(): Server {
+  server = createServer((req, res) => {
+    handleRequest(req, res).catch((err) => {
+      console.error("Unhandled HTTP error:", err);
+      if (!res.headersSent) {
+        res.writeHead(500, { "Content-Type": "application/json" });
+        res.end(JSON.stringify({ error: "Internal server error" }));
+      }
+    });
+  });
+
+  server.on("error", (err: NodeJS.ErrnoException) => {
+    if (err.code === "EADDRINUSE") {
+      console.error(`   API server port ${config.port} already in use`);
+    } else {
+      console.error("API server error:", err);
+    }
+  });
+  server.listen(config.port, () => {
+    console.log(`   API server: http://localhost:${config.port}`);
+  });
+
+  return server;
+}
+
+/**
+ * Stop the HTTP API server gracefully.
+ */
+export async function stopApiServer(): Promise<void> {
+  if (!server) return;
+
+  return new Promise((resolve) => {
+    server!.close(() => {
+      console.log("   API server stopped");
+      server = null;
+      resolve();
+    });
+  });
+}

--- a/src/config.ts
+++ b/src/config.ts
@@ -34,6 +34,7 @@ export const config = {
   // Path to oh-my-pi CLI (packages/coding-agent/dist/cli.js)
   // Required for agent process management
   ompCliPath: process.env.OMP_CLI_PATH ?? "",
+  port: parseInt(process.env.MIRANDA_PORT ?? "3847", 10),
 } as const;
 
 export function validateConfig(): void {
@@ -47,5 +48,9 @@ export function validateConfig(): void {
   }
   if (config.allowedUserIds.length === 0) {
     console.warn("Warning: ALLOWED_USER_IDS not set, bot will reject all users");
+  }
+  if (isNaN(config.port) || config.port < 1 || config.port > 65535) {
+    console.error(`Invalid MIRANDA_PORT: ${process.env.MIRANDA_PORT}`);
+    process.exit(1);
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,6 +16,7 @@ import {
   getRestartChatId,
   clearRestartChatId,
 } from "./state/sessions.js";
+import { startApiServer, stopApiServer } from "./api/server.js";
 
 // Validate configuration
 validateConfig();
@@ -38,6 +39,7 @@ export async function gracefulShutdown(): Promise<void> {
     // Stop bot polling first (prevents new commands)
     await bot.stop();
     console.log("   Bot stopped");
+    await stopApiServer();
 
     // Kill all agent processes
     const agents = getAllAgents();
@@ -270,6 +272,9 @@ bot.start({
     }
 
     console.log("Miranda is ready");
+
+    // Start API server
+    startApiServer();
   },
 }).catch((err) => {
   console.error("Failed to start:", err);


### PR DESCRIPTION
Closes #78

## Summary

Adds an HTTP server to Miranda that serves both a REST API and static files, providing the foundation for the control center Mini App.

### New files
- `src/api/server.ts` — HTTP server setup, static file serving, route dispatch
- `src/api/routes.ts` — API route handlers
- `public/index.html` — placeholder for Mini App static files

### API Endpoints
- `GET /api/sessions` — All sessions with status, elapsed time, skill type
- `GET /api/projects` — All projects from PROJECTS_DIR with task counts
- `POST /api/sessions/:id/stop` — Stop a session by taskId
- `GET /` — Serve public/index.html (Mini App)
- `GET /*` — Serve static files from public/

### Changes to existing files
- `src/config.ts` — Added `port` config from `MIRANDA_PORT` env var (default: 3847) with validation
- `src/index.ts` — Start API server alongside bot, integrate with graceful shutdown
- `.env.example` — Added `MIRANDA_PORT` documentation

### Design decisions
- Uses Node built-in `http` module (no Express) per issue requirements
- Switch/case style router in routes.ts
- CORS enabled for all origins (Mini App runs in Telegram WebView)
- No auth (served behind Tailscale per issue spec)
- Path traversal protection for static file serving
- Server error handler for EADDRINUSE and other listen failures