### PR TITLE
Add GitHub integration API for issues, PRs, and dependency parsing

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,6 +2,7 @@
 TELEGRAM_BOT_TOKEN=xxx                    # From @BotFather
 ALLOWED_USER_IDS=123,456                  # Telegram user IDs (comma-separated)
 OMP_CLI_PATH=/home/user/.bun/bin/omp      # Path to oh-my-pi CLI binary
+GITHUB_TOKEN=ghp_xxx                          # GitHub PAT for API access (issues, PRs, merge)
 
 # Optional
 PROJECTS_DIR=~/projects                   # Directory to scan for projects (default: ~/projects)

--- a/src/api/auth.ts
+++ b/src/api/auth.ts
@@ -1,0 +1,83 @@
+import { createHmac, timingSafeEqual } from "node:crypto";
+import { config } from "../config.js";
+
+export interface TelegramUser {
+  id: number;
+  first_name: string;
+  last_name?: string;
+  username?: string;
+  language_code?: string;
+}
+
+/**
+ * Validate Telegram Mini App initData.
+ *
+ * The Mini App frontend sends initData (from Telegram.WebApp.initData) as the
+ * x-telegram-init-data header. Server-side validation:
+ * 1. Parse the query string
+ * 2. Extract hash, sort remaining fields alphabetically
+ * 3. HMAC-SHA-256: secret = HMAC("WebAppData", BOT_TOKEN), then HMAC(secret, check_string)
+ * 4. Compare computed hash with received hash (timing-safe)
+ * 5. Check auth_date freshness (1 hour window)
+ * 6. Extract user.id, verify against ALLOWED_USER_IDS
+ *
+ * Returns the validated TelegramUser or null if validation fails.
+ */
+export function validateInitData(initData: string): TelegramUser | null {
+  if (!initData) return null;
+
+  let params: URLSearchParams;
+  try {
+    params = new URLSearchParams(initData);
+  } catch {
+    return null;
+  }
+
+  const hash = params.get("hash");
+  if (!hash) return null;
+
+  // Build check string: all params except hash, sorted alphabetically, newline-joined
+  params.delete("hash");
+  const checkString = [...params.entries()]
+    .sort(([a], [b]) => a.localeCompare(b))
+    .map(([k, v]) => `${k}=${v}`)
+    .join("\n");
+
+  // HMAC validation
+  const secret = createHmac("sha256", "WebAppData")
+    .update(config.botToken)
+    .digest();
+  const computed = createHmac("sha256", secret)
+    .update(checkString)
+    .digest("hex");
+
+  // Timing-safe comparison
+  if (computed.length !== hash.length) return null;
+  const computedBuf = Buffer.from(computed, "hex");
+  const hashBuf = Buffer.from(hash, "hex");
+  if (computedBuf.length !== hashBuf.length) return null;
+  if (!timingSafeEqual(computedBuf, hashBuf)) return null;
+
+  // Check auth_date freshness (1 hour window)
+  const authDate = parseInt(params.get("auth_date") ?? "0", 10);
+  const nowSeconds = Math.floor(Date.now() / 1000);
+  if (nowSeconds - authDate > 3600) return null;
+
+  // Extract and validate user
+  const userStr = params.get("user");
+  if (!userStr) return null;
+
+  let user: TelegramUser;
+  try {
+    user = JSON.parse(userStr) as TelegramUser;
+  } catch {
+    return null;
+  }
+
+  if (typeof user.id !== "number") return null;
+
+  // Check against allowed user IDs
+  if (!config.allowedUserIds.includes(user.id)) return null;
+
+  return user;
+}

--- a/src/api/deps.ts
+++ b/src/api/deps.ts
@@ -1,0 +1,51 @@
+/**
+ * Parse dependency references from an issue body.
+ *
+ * Recognizes patterns written by oh-plan and common variations:
+ * - **Depends on:** #43 (oh-plan standard format, with bold)
+ * - *Depends on:* #43 (italic variant)
+ * - Depends on: #43, #44 (comma-separated, with colon)
+ * - Depends on #43 (without colon)
+ * - Depends on: #43 and #44 (with "and" separator)
+ *
+ * Returns deduplicated array of issue numbers.
+ */
+export function parseDependencies(body: string | null | undefined): number[] {
+  if (!body) return [];
+
+  const deps = new Set<number>();
+
+  // Match "Depends on" with optional bold/italic markers and optional colon,
+  // followed by one or more #N references separated by commas, "and", or whitespace
+  const pattern = /\*{0,2}Depends on:?\*{0,2}:?\s*(.+)/gi;
+
+  let match: RegExpExecArray | null;
+  while ((match = pattern.exec(body)) !== null) {
+    const rest = match[1];
+    // Extract all #N references from the remainder of the line
+    const refs = rest.match(/#(\d+)/g);
+    if (refs) {
+      for (const ref of refs) {
+        const num = parseInt(ref.slice(1), 10);
+        if (!isNaN(num) && num > 0) {
+          deps.add(num);
+        }
+      }
+    }
+  }
+
+  return [...deps];
+}
+
+/**
+ * Compute which issues are blocked.
+ * An issue is blocked if any of its dependsOn issues are not yet resolved
+ * (i.e., have no merged PR).
+ *
+ * @param dependsOn - issue numbers this issue depends on
+ * @param mergedIssues - set of issue numbers that have a merged PR
+ * @returns issue numbers from dependsOn that are NOT yet merged
+ */
+export function computeBlockedBy(dependsOn: number[], mergedIssues: Set<number>): number[] {
+  return dependsOn.filter((num) => !mergedIssues.has(num));
+}

--- a/src/api/github.ts
+++ b/src/api/github.ts
@@ -1,0 +1,314 @@
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+
+const execFileAsync = promisify(execFile);
+
+const GITHUB_API = "https://api.github.com";
+
+/** Cached owner/repo per project path. */
+const repoInfoCache = new Map<string, { owner: string; repo: string }>();
+
+export interface GitHubIssue {
+  number: number;
+  title: string;
+  state: string;
+  labels: string[];
+  body: string | null;
+}
+
+export interface GitHubPR {
+  number: number;
+  title: string;
+  state: string;
+  /** Whether the PR can be merged (no conflicts). */
+  mergeable: boolean | null;
+  html_url: string;
+  /** Branch the PR merges into. */
+  base: string;
+  /** Branch the PR is from. */
+  head: string;
+  body: string | null;
+}
+
+export interface GitHubMergeResult {
+  merged: boolean;
+  message: string;
+  sha?: string;
+}
+
+/**
+ * Get the GitHub token from environment.
+ * Uses GITHUB_TOKEN (standard for gh CLI and CI).
+ */
+function getToken(): string {
+  const token = process.env.GITHUB_TOKEN ?? "";
+  if (!token) {
+    throw new Error("GITHUB_TOKEN environment variable is not set");
+  }
+  return token;
+}
+
+/**
+ * Make an authenticated GitHub API request.
+ * Throws on non-2xx responses with the error message from GitHub.
+ * Returns parsed JSON.
+ */
+async function githubFetch<T>(
+  path: string,
+  options: {
+    method?: string;
+    body?: unknown;
+    token?: string;
+  } = {}
+): Promise<T> {
+  const token = options.token ?? getToken();
+  const method = options.method ?? "GET";
+
+  const headers: Record<string, string> = {
+    Authorization: `Bearer ${token}`,
+    Accept: "application/vnd.github+json",
+    "X-GitHub-Api-Version": "2022-11-28",
+    "User-Agent": "miranda-bot",
+  };
+
+  const init: RequestInit = { method, headers };
+  if (options.body !== undefined) {
+    headers["Content-Type"] = "application/json";
+    init.body = JSON.stringify(options.body);
+  }
+
+  const url = path.startsWith("http") ? path : `${GITHUB_API}${path}`;
+  const res = await fetch(url, init);
+
+  // Check rate limiting
+  const remaining = res.headers.get("x-ratelimit-remaining");
+  if (remaining !== null && parseInt(remaining, 10) === 0) {
+    const resetAt = res.headers.get("x-ratelimit-reset");
+    const resetDate = resetAt ? new Date(parseInt(resetAt, 10) * 1000).toISOString() : "unknown";
+    throw new GitHubRateLimitError(`GitHub API rate limit exhausted. Resets at ${resetDate}`);
+  }
+
+  if (!res.ok) {
+    let errorMessage: string;
+    try {
+      const errorBody = (await res.json()) as { message?: string };
+      errorMessage = errorBody.message ?? res.statusText;
+    } catch {
+      errorMessage = res.statusText;
+    }
+    throw new Error(`GitHub API ${method} ${path}: ${res.status} ${errorMessage}`);
+  }
+
+  // 204 No Content
+  if (res.status === 204) {
+    return undefined as T;
+  }
+
+  return (await res.json()) as T;
+}
+
+export class GitHubRateLimitError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "GitHubRateLimitError";
+  }
+}
+
+/**
+ * Detect owner/repo from git remote in a project directory.
+ * Parses the origin remote URL (HTTPS or SSH format).
+ * Results are cached per project path.
+ */
+export async function getRepoInfo(projectPath: string): Promise<{ owner: string; repo: string }> {
+  const cached = repoInfoCache.get(projectPath);
+  if (cached) return cached;
+
+  const { stdout } = await execFileAsync("git", ["remote", "get-url", "origin"], {
+    cwd: projectPath,
+  });
+  const url = stdout.trim();
+
+  // Parse HTTPS: https://github.com/owner/repo.git
+  // Parse SSH: git@github.com:owner/repo.git
+  let match = url.match(/github\.com[/:]([^/]+)\/([^/.]+)(?:\.git)?$/);
+  if (!match) {
+    // Try generic patterns
+    match = url.match(/[/:]([^/]+)\/([^/.]+?)(?:\.git)?$/);
+  }
+  if (!match) {
+    throw new Error(`Cannot parse GitHub owner/repo from remote URL: ${url}`);
+  }
+
+  const info = { owner: match[1], repo: match[2] };
+  repoInfoCache.set(projectPath, info);
+  return info;
+}
+
+/**
+ * Fetch all open issues for a repository.
+ * Paginates automatically (100 per page).
+ */
+export async function getOpenIssues(
+  owner: string,
+  repo: string
+): Promise<GitHubIssue[]> {
+  const issues: GitHubIssue[] = [];
+  let page = 1;
+
+  while (true) {
+    // GitHub's issues endpoint includes PRs — filter them out by checking pull_request field
+    const raw = await githubFetch<Array<{
+      number: number;
+      title: string;
+      state: string;
+      labels: Array<{ name: string }>;
+      body: string | null;
+      pull_request?: unknown;
+    }>>(`/repos/${owner}/${repo}/issues?state=open&per_page=100&page=${page}`);
+
+    if (raw.length === 0) break;
+
+    for (const item of raw) {
+      // Skip pull requests (GitHub includes them in issues endpoint)
+      if (item.pull_request) continue;
+
+      issues.push({
+        number: item.number,
+        title: item.title,
+        state: item.state,
+        labels: item.labels.map((l) => l.name),
+        body: item.body,
+      });
+    }
+
+    if (raw.length < 100) break;
+    page++;
+  }
+
+  return issues;
+}
+
+/**
+ * Fetch all open PRs for a repository.
+ * Paginates automatically.
+ */
+export async function getOpenPRs(
+  owner: string,
+  repo: string
+): Promise<GitHubPR[]> {
+  const prs: GitHubPR[] = [];
+  let page = 1;
+
+  while (true) {
+    const raw = await githubFetch<Array<{
+      number: number;
+      title: string;
+      state: string;
+      mergeable: boolean | null;
+      html_url: string;
+      base: { ref: string };
+      head: { ref: string };
+      body: string | null;
+    }>>(`/repos/${owner}/${repo}/pulls?state=open&per_page=100&page=${page}`);
+
+    if (raw.length === 0) break;
+
+    for (const item of raw) {
+      prs.push({
+        number: item.number,
+        title: item.title,
+        state: item.state,
+        mergeable: item.mergeable,
+        html_url: item.html_url,
+        base: item.base.ref,
+        head: item.head.ref,
+        body: item.body,
+      });
+    }
+
+    if (raw.length < 100) break;
+    page++;
+  }
+
+  return prs;
+}
+
+/**
+ * Squash-merge a pull request.
+ */
+export async function mergePR(
+  owner: string,
+  repo: string,
+  prNumber: number
+): Promise<GitHubMergeResult> {
+  try {
+    const result = await githubFetch<{
+      merged: boolean;
+      message: string;
+      sha: string;
+    }>(`/repos/${owner}/${repo}/pulls/${prNumber}/merge`, {
+      method: "PUT",
+      body: { merge_method: "squash" },
+    });
+    return { merged: result.merged, message: result.message, sha: result.sha };
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    return { merged: false, message };
+  }
+}
+
+/**
+ * Post a comment on a PR (or issue — same API).
+ */
+export async function commentOnPR(
+  owner: string,
+  repo: string,
+  prNumber: number,
+  body: string
+): Promise<{ id: number; html_url: string }> {
+  return githubFetch<{ id: number; html_url: string }>(
+    `/repos/${owner}/${repo}/issues/${prNumber}/comments`,
+    {
+      method: "POST",
+      body: { body },
+    }
+  );
+}
+
+/**
+ * Find PRs linked to a specific issue number.
+ *
+ * Checks:
+ * 1. PR branch name contains `issue-N` or `issue/N`
+ * 2. PR body contains `Closes #N`, `Fixes #N`, or `Resolves #N`
+ */
+export function findLinkedPR(
+  prs: GitHubPR[],
+  issueNumber: number
+): GitHubPR | null {
+  const issueStr = String(issueNumber);
+
+  for (const pr of prs) {
+    // Check branch name patterns: issue-N, issue/N, N-description
+    const branchPatterns = [
+      new RegExp(`issue[/-]${issueStr}(?:\\b|$)`),
+      new RegExp(`^${issueStr}-`),
+    ];
+    if (branchPatterns.some((p) => p.test(pr.head))) {
+      return pr;
+    }
+
+    // Check PR body for closing references
+    if (pr.body) {
+      const closingPattern = new RegExp(
+        `(?:closes|fixes|resolves)\\s+#${issueStr}\\b`,
+        "i"
+      );
+      if (closingPattern.test(pr.body)) {
+        return pr;
+      }
+    }
+  }
+
+  return null;
+}

--- a/src/api/routes.ts
+++ b/src/api/routes.ts
@@ -1,7 +1,26 @@
 import type { IncomingMessage, ServerResponse } from "node:http";
-import { getAllSessions, getSession, deleteSession } from "../state/sessions.js";
-import { scanProjects } from "../projects/scanner.js";
-import { stopSession } from "../bot/commands.js";
+import { getAllSessions, getSession, deleteSession, setSession } from "../state/sessions.js";
+import { scanProjects, pullProject } from "../projects/scanner.js";
+import { stopSession, spawnSession, type SpawnOptions } from "../bot/commands.js";
+import { validateInitData } from "./auth.js";
+import { parseDependencies } from "./deps.js";
+import {
+  getRepoInfo,
+  getOpenIssues,
+  getOpenPRs,
+  mergePR,
+  commentOnPR,
+  findLinkedPR,
+  GitHubRateLimitError,
+  type GitHubPR,
+} from "./github.js";
+import type { Session } from "../types.js";
+
+const CORS_HEADERS = {
+  "Access-Control-Allow-Origin": "*",
+  "Access-Control-Allow-Methods": "GET, POST, PUT, OPTIONS",
+  "Access-Control-Allow-Headers": "Content-Type, x-telegram-init-data",
+};
 
 /**
  * Format elapsed time since a date as a human-readable string.
@@ -24,11 +43,61 @@ function json(res: ServerResponse, status: number, body: unknown): void {
   const payload = JSON.stringify(body);
   res.writeHead(status, {
     "Content-Type": "application/json",
-    "Access-Control-Allow-Origin": "*",
-    "Access-Control-Allow-Methods": "GET, POST, OPTIONS",
-    "Access-Control-Allow-Headers": "Content-Type",
+    ...CORS_HEADERS,
   });
   res.end(payload);
+}
+
+/**
+ * Read the request body as a string.
+ */
+function readBody(req: IncomingMessage): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const chunks: Buffer[] = [];
+    req.on("data", (chunk: Buffer) => chunks.push(chunk));
+    req.on("end", () => resolve(Buffer.concat(chunks).toString("utf-8")));
+    req.on("error", reject);
+  });
+}
+
+/**
+ * Parse JSON body from request. Returns null on parse failure.
+ */
+async function parseJsonBody<T>(req: IncomingMessage): Promise<T | null> {
+  try {
+    const raw = await readBody(req);
+    if (!raw.trim()) return null;
+    return JSON.parse(raw) as T;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Authenticate an API request using Telegram initData.
+ * Returns true if authenticated, false if 401 was sent.
+ */
+function requireAuth(req: IncomingMessage, res: ServerResponse): boolean {
+  const initData = req.headers["x-telegram-init-data"];
+  if (typeof initData !== "string" || !initData) {
+    json(res, 401, { error: "Missing x-telegram-init-data header" });
+    return false;
+  }
+  const user = validateInitData(initData);
+  if (!user) {
+    json(res, 401, { error: "Invalid or expired authentication" });
+    return false;
+  }
+  return true;
+}
+
+/**
+ * Resolve a project name to its path. Returns null if not found.
+ */
+async function resolveProject(name: string): Promise<string | null> {
+  const projects = await scanProjects();
+  const project = projects.find((p) => p.name === name);
+  return project?.path ?? null;
 }
 
 
@@ -100,6 +169,299 @@ export async function handleStopSession(
 }
 
 /**
+ * GET /api/projects/:name/issues — Open issues with parsed dependencies.
+ */
+async function handleGetIssues(
+  _req: IncomingMessage,
+  res: ServerResponse,
+  projectName: string
+): Promise<void> {
+  const projectPath = await resolveProject(projectName);
+  if (!projectPath) {
+    json(res, 404, { error: `Project "${projectName}" not found` });
+    return;
+  }
+
+  try {
+    const { owner, repo } = await getRepoInfo(projectPath);
+    const [issues, prs] = await Promise.all([
+      getOpenIssues(owner, repo),
+      getOpenPRs(owner, repo),
+    ]);
+
+    // Build set of issue numbers that have a merged PR (approximation: check closed PRs
+    // that reference the issue). For open issues, we check if there's a linked open PR.
+    // We consider an issue "resolved" for blocking purposes if it has an open PR that
+    // is linked to it — but truly resolved means merged. Since we only fetch open PRs,
+    // we'll use the absence of the issue from our open issues list as the merge indicator.
+    // Issues that are closed are not in our list (we only fetch state=open).
+    // For blockedBy computation, an issue is blocked if its dependency is still open
+    // (still appears in our open issues list) AND has no linked PR ready to merge.
+    const openIssueNumbers = new Set(issues.map((i) => i.number));
+
+    // Issues with a merged PR are NOT in our open issues list (they'd be closed).
+    // So mergedIssues = all issue numbers that are NOT in openIssueNumbers.
+    // We don't know all closed issues, but for blocking:
+    // If a dependency is not in open issues, it's either closed/merged or doesn't exist.
+    // Either way, it's not blocking. If it IS open, it IS blocking.
+    // So: mergedIssues is the complement of openIssueNumbers — we pass openIssueNumbers as "unresolved".
+    const result = issues.map((issue) => {
+      const dependsOn = parseDependencies(issue.body);
+      const blockedBy = dependsOn.filter((dep) => openIssueNumbers.has(dep));
+      const linkedPR = findLinkedPR(prs, issue.number);
+
+      return {
+        number: issue.number,
+        title: issue.title,
+        state: issue.state,
+        labels: issue.labels,
+        dependsOn,
+        blockedBy,
+        pr: linkedPR
+          ? {
+              number: linkedPR.number,
+              state: linkedPR.state,
+              mergeable: linkedPR.mergeable,
+              url: linkedPR.html_url,
+            }
+          : null,
+      };
+    });
+
+    json(res, 200, { issues: result });
+  } catch (error) {
+    if (error instanceof GitHubRateLimitError) {
+      json(res, 429, { error: error.message });
+      return;
+    }
+    const message = error instanceof Error ? error.message : String(error);
+    json(res, 500, { error: message });
+  }
+}
+
+/**
+ * GET /api/projects/:name/prs — Open PRs with linked issue info.
+ */
+async function handleGetPRs(
+  _req: IncomingMessage,
+  res: ServerResponse,
+  projectName: string
+): Promise<void> {
+  const projectPath = await resolveProject(projectName);
+  if (!projectPath) {
+    json(res, 404, { error: `Project "${projectName}" not found` });
+    return;
+  }
+
+  try {
+    const { owner, repo } = await getRepoInfo(projectPath);
+    const prs = await getOpenPRs(owner, repo);
+
+    const result = prs.map((pr) => {
+      // Extract linked issue numbers from PR body and branch name
+      const linkedIssues = extractLinkedIssueNumbers(pr);
+
+      return {
+        number: pr.number,
+        title: pr.title,
+        state: pr.state,
+        mergeable: pr.mergeable,
+        url: pr.html_url,
+        base: pr.base,
+        head: pr.head,
+        linkedIssues,
+      };
+    });
+
+    json(res, 200, { prs: result });
+  } catch (error) {
+    if (error instanceof GitHubRateLimitError) {
+      json(res, 429, { error: error.message });
+      return;
+    }
+    const message = error instanceof Error ? error.message : String(error);
+    json(res, 500, { error: message });
+  }
+}
+
+/**
+ * Extract issue numbers linked from a PR (via body references and branch name).
+ */
+function extractLinkedIssueNumbers(pr: GitHubPR): number[] {
+  const issues = new Set<number>();
+
+  // Check branch name: issue-N, issue/N
+  const branchMatch = pr.head.match(/issue[/-](\d+)/);
+  if (branchMatch) {
+    issues.add(parseInt(branchMatch[1], 10));
+  }
+
+  // Check body for Closes/Fixes/Resolves #N
+  if (pr.body) {
+    const pattern = /(?:closes|fixes|resolves)\s+#(\d+)/gi;
+    let match: RegExpExecArray | null;
+    while ((match = pattern.exec(pr.body)) !== null) {
+      issues.add(parseInt(match[1], 10));
+    }
+  }
+
+  return [...issues];
+}
+
+/**
+ * POST /api/projects/:name/issues/:num/start — Kick off oh-task for an issue.
+ */
+async function handleStartIssue(
+  req: IncomingMessage,
+  res: ServerResponse,
+  projectName: string,
+  issueNumber: string
+): Promise<void> {
+  const projectPath = await resolveProject(projectName);
+  if (!projectPath) {
+    json(res, 404, { error: `Project "${projectName}" not found` });
+    return;
+  }
+
+  // Pull latest changes before starting (matches Telegram command behavior)
+  try {
+    await pullProject(projectPath);
+  } catch {
+    // Best-effort pull — continue even if it fails
+  }
+
+  // Parse optional body for baseBranch and chatId
+  const body = await parseJsonBody<{ baseBranch?: string; chatId?: number }>(req);
+  const baseBranch = body?.baseBranch;
+  // chatId is required to know where to send Telegram notifications
+  const chatId = body?.chatId;
+  if (!chatId) {
+    json(res, 400, { error: "chatId is required in request body" });
+    return;
+  }
+
+  // Check for existing session
+  const sessionKey = `oh-task-${projectName}-${issueNumber}`;
+  const existing = getSession(sessionKey);
+  if (existing) {
+    json(res, 409, {
+      error: `Session already exists for ${projectName} #${issueNumber}`,
+      session: { taskId: existing.taskId, status: existing.status },
+    });
+    return;
+  }
+
+  try {
+    const spawnOptions: SpawnOptions = { projectPath, projectName };
+    if (baseBranch) {
+      spawnOptions.baseBranch = baseBranch;
+    }
+    const sessionId = await spawnSession("oh-task", issueNumber, chatId, spawnOptions);
+
+    const session: Session = {
+      taskId: sessionKey,
+      sessionId,
+      skill: "oh-task",
+      status: "running",
+      startedAt: new Date(),
+      chatId,
+    };
+    setSession(sessionKey, session);
+
+    json(res, 201, {
+      taskId: sessionKey,
+      sessionId,
+      issueNumber: parseInt(issueNumber, 10),
+    });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    json(res, 500, { error: message });
+  }
+}
+
+/**
+ * POST /api/projects/:name/prs/:num/merge — Squash-merge a PR.
+ */
+async function handleMergePR(
+  _req: IncomingMessage,
+  res: ServerResponse,
+  projectName: string,
+  prNumber: string
+): Promise<void> {
+  const projectPath = await resolveProject(projectName);
+  if (!projectPath) {
+    json(res, 404, { error: `Project "${projectName}" not found` });
+    return;
+  }
+
+  const num = parseInt(prNumber, 10);
+  if (isNaN(num) || num <= 0) {
+    json(res, 400, { error: "Invalid PR number" });
+    return;
+  }
+
+  try {
+    const { owner, repo } = await getRepoInfo(projectPath);
+    const result = await mergePR(owner, repo, num);
+
+    if (result.merged) {
+      json(res, 200, result);
+    } else {
+      json(res, 422, result);
+    }
+  } catch (error) {
+    if (error instanceof GitHubRateLimitError) {
+      json(res, 429, { error: error.message });
+      return;
+    }
+    const message = error instanceof Error ? error.message : String(error);
+    json(res, 500, { error: message });
+  }
+}
+
+/**
+ * POST /api/projects/:name/prs/:num/comment — Post a review comment on a PR.
+ */
+async function handleCommentPR(
+  req: IncomingMessage,
+  res: ServerResponse,
+  projectName: string,
+  prNumber: string
+): Promise<void> {
+  const projectPath = await resolveProject(projectName);
+  if (!projectPath) {
+    json(res, 404, { error: `Project "${projectName}" not found` });
+    return;
+  }
+
+  const num = parseInt(prNumber, 10);
+  if (isNaN(num) || num <= 0) {
+    json(res, 400, { error: "Invalid PR number" });
+    return;
+  }
+
+  const body = await parseJsonBody<{ body?: string }>(req);
+  if (!body?.body || typeof body.body !== "string" || !body.body.trim()) {
+    json(res, 400, { error: "Request body must include non-empty 'body' field" });
+    return;
+  }
+
+  try {
+    const { owner, repo } = await getRepoInfo(projectPath);
+    const result = await commentOnPR(owner, repo, num, body.body);
+    json(res, 201, { id: result.id, url: result.html_url });
+  } catch (error) {
+    if (error instanceof GitHubRateLimitError) {
+      json(res, 429, { error: error.message });
+      return;
+    }
+    const message = error instanceof Error ? error.message : String(error);
+    json(res, 500, { error: message });
+  }
+}
+
+
+/**
  * Route an API request to the appropriate handler.
  * Returns true if a route matched, false otherwise.
  */
@@ -110,16 +472,20 @@ export async function routeApi(
 ): Promise<boolean> {
   const method = req.method ?? "GET";
 
-  // Handle CORS preflight
+  // Handle CORS preflight (no auth required)
   if (method === "OPTIONS") {
-    res.writeHead(204, {
-      "Access-Control-Allow-Origin": "*",
-      "Access-Control-Allow-Methods": "GET, POST, OPTIONS",
-      "Access-Control-Allow-Headers": "Content-Type",
-    });
+    res.writeHead(204, CORS_HEADERS);
     res.end();
     return true;
   }
+
+  // Only handle /api/* routes
+  if (!pathname.startsWith("/api/")) return false;
+
+  // All /api/* routes require Telegram initData authentication
+  if (!requireAuth(req, res)) return true;
+
+  // --- Existing routes ---
 
   if (pathname === "/api/sessions" && method === "GET") {
     handleGetSessions(req, res);
@@ -135,6 +501,43 @@ export async function routeApi(
   const stopMatch = pathname.match(/^\/api\/sessions\/([^/]+)\/stop$/);
   if (stopMatch && method === "POST") {
     await handleStopSession(req, res, decodeURIComponent(stopMatch[1]));
+    return true;
+  }
+
+  // --- GitHub integration routes ---
+
+  // GET /api/projects/:name/issues
+  const issuesMatch = pathname.match(/^\/api\/projects\/([^/]+)\/issues$/);
+  if (issuesMatch && method === "GET") {
+    await handleGetIssues(req, res, decodeURIComponent(issuesMatch[1]));
+    return true;
+  }
+
+  // GET /api/projects/:name/prs
+  const prsMatch = pathname.match(/^\/api\/projects\/([^/]+)\/prs$/);
+  if (prsMatch && method === "GET") {
+    await handleGetPRs(req, res, decodeURIComponent(prsMatch[1]));
+    return true;
+  }
+
+  // POST /api/projects/:name/issues/:num/start
+  const startMatch = pathname.match(/^\/api\/projects\/([^/]+)\/issues\/(\d+)\/start$/);
+  if (startMatch && method === "POST") {
+    await handleStartIssue(req, res, decodeURIComponent(startMatch[1]), startMatch[2]);
+    return true;
+  }
+
+  // POST /api/projects/:name/prs/:num/merge
+  const mergeMatch = pathname.match(/^\/api\/projects\/([^/]+)\/prs\/(\d+)\/merge$/);
+  if (mergeMatch && method === "POST") {
+    await handleMergePR(req, res, decodeURIComponent(mergeMatch[1]), mergeMatch[2]);
+    return true;
+  }
+
+  // POST /api/projects/:name/prs/:num/comment
+  const commentMatch = pathname.match(/^\/api\/projects\/([^/]+)\/prs\/(\d+)\/comment$/);
+  if (commentMatch && method === "POST") {
+    await handleCommentPR(req, res, decodeURIComponent(commentMatch[1]), commentMatch[2]);
     return true;
   }
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -34,6 +34,7 @@ export const config = {
   // Path to oh-my-pi CLI (packages/coding-agent/dist/cli.js)
   // Required for agent process management
   ompCliPath: process.env.OMP_CLI_PATH ?? "",
+  githubToken: process.env.GITHUB_TOKEN ?? "",
   port: parseInt(process.env.MIRANDA_PORT ?? "3847", 10),
 } as const;
 


### PR DESCRIPTION
Closes #79

## Summary

Adds GitHub integration API endpoints with Telegram Mini App authentication, giving the control center frontend the data it needs to show task status, PR state, and dependency relationships.

### New files

- **`src/api/auth.ts`** - Telegram initData validation middleware (HMAC-SHA-256, timing-safe, 1-hour window, ALLOWED_USER_IDS check)
- **`src/api/deps.ts`** - Dependency parser for issue bodies (oh-plan standard format and variations)
- **`src/api/github.ts`** - GitHub API client (fetch-based, Bearer token, pagination, rate limit detection, PR-issue linking)

### API Endpoints

| Method | Path | Description |
|--------|------|-------------|
| GET | `/api/projects/:name/issues` | Open issues with parsed dependencies and linked PR |
| GET | `/api/projects/:name/prs` | Open PRs with linked issue numbers |
| POST | `/api/projects/:name/issues/:num/start` | Kick off oh-task session |
| POST | `/api/projects/:name/prs/:num/merge` | Squash-merge a PR |
| POST | `/api/projects/:name/prs/:num/comment` | Post a review comment |

### Other changes

- All `/api/*` routes gated by Telegram initData auth; static files remain public
- CORS headers updated to allow `x-telegram-init-data` header
- `GITHUB_TOKEN` added to `.env.example` and `config.ts`
- Pulls latest changes before starting oh-task via API (matches Telegram command behavior)