### PR TITLE
Add clickable links and squash-merge button to control center

### DIFF
--- a/public/style.css
+++ b/public/style.css
@@ -308,11 +308,17 @@ html, body {
   gap: 8px;
 }
 
-.issue-number {
+a.issue-number {
   font-size: 13px;
   font-weight: 700;
-  color: var(--tg-theme-hint-color);
+  color: var(--tg-theme-link-color);
   flex-shrink: 0;
+  text-decoration: none;
+  cursor: pointer;
+}
+
+a.issue-number:active {
+  opacity: 0.7;
 }
 
 .issue-title {
@@ -346,10 +352,15 @@ html, body {
   background: rgba(255, 255, 255, 0.04);
 }
 
-.pr-status {
+a.pr-status {
   font-weight: 600;
+  text-decoration: none;
+  cursor: pointer;
 }
 
+a.pr-status:active {
+  opacity: 0.7;
+}
 .pr-status.ready { color: #30d158; }
 .pr-status.conflicts { color: #ff9f0a; }
 .pr-status.open { color: var(--tg-theme-hint-color); }
@@ -363,6 +374,24 @@ html, body {
   display: flex;
   gap: 6px;
   flex-wrap: wrap;
+}
+
+.btn-merge {
+  background: #30d158;
+  color: #000;
+}
+
+.btn-merge-disabled {
+  background: rgba(255, 255, 255, 0.08);
+  color: var(--tg-theme-hint-color);
+  cursor: default;
+  opacity: 0.6;
+}
+
+.btn-merge-done {
+  background: rgba(48, 209, 88, 0.15);
+  color: #30d158;
+  cursor: default;
 }
 
 /* --- Modal --- */

--- a/src/api/routes.ts
+++ b/src/api/routes.ts
@@ -228,7 +228,8 @@ async function handleGetIssues(
       };
     });
 
-    json(res, 200, { issues: result });
+    const repoUrl = `https://github.com/${owner}/${repo}`;
+    json(res, 200, { repoUrl, issues: result });
   } catch (error) {
     if (error instanceof GitHubRateLimitError) {
       json(res, 429, { error: error.message });


### PR DESCRIPTION
Closes #86

## Summary

Makes the control center actionable with clickable links and merge controls:

### Issue Links
- Issue numbers (e.g. `#43`) are now clickable links to GitHub issues
- Uses `Telegram.WebApp.openLink()` to open in external browser without closing the Mini App
- `repoUrl` added to the issues API endpoint response for constructing URLs

### PR Links
- PR status badges (e.g. `PR #51 ready`) link to the GitHub PR page
- PR URL comes from the existing `pr.url` field in the API response

### Squash-Merge Button
- Mergeable PRs show a green **Merge** button
- Confirmation dialog before merge
- Visual feedback: button shows "Merging..." during request, then "Merged" on success
- Non-mergeable PRs show a grey **Conflicts** badge (disabled, not a button)
- PRs with unknown mergability show a grey **Checking...** badge

### Files Changed
- `src/api/routes.ts` - Added `repoUrl` to GET `/api/projects/:name/issues` response
- `public/app.js` - Clickable links via `openLink()`, merge confirmation, visual states
- `public/style.css` - Styles for link elements, merge button states