### PR TITLE
Add self-update and restart buttons to control center

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -61,6 +61,12 @@
   var $commentText = document.getElementById("comment-text");
   var $commentCancel = document.getElementById("comment-cancel");
   var $commentSubmit = document.getElementById("comment-submit");
+  var $adminStatus = document.getElementById("admin-status");
+  var $updateBtn = document.getElementById("update-btn");
+  var $restartBtn = document.getElementById("restart-btn");
+  var $updateRestartBtn = document.getElementById("update-restart-btn");
+
+  var adminBusy = false; // prevents concurrent admin operations
 
   // ---------------------------------------------------------------------------
   // API layer
@@ -606,6 +612,154 @@
     if (e.target === $commentModal) {
       closeCommentModal();
     }
+  });
+
+  // --- Admin button handlers ---
+
+  function setAdminBusy(busy) {
+    adminBusy = busy;
+    $updateBtn.disabled = busy;
+    $restartBtn.disabled = busy;
+    $updateRestartBtn.disabled = busy;
+  }
+
+  function setAdminStatus(html) {
+    $adminStatus.innerHTML = html;
+  }
+
+  function doSelfUpdate() {
+    if (adminBusy) return Promise.resolve();
+    setAdminBusy(true);
+    $updateBtn.textContent = "Updating\u2026";
+    $updateBtn.classList.add("updating");
+    setAdminStatus('<span class="status-info">Pulling and building\u2026</span>');
+
+    return api("POST", "/api/selfupdate")
+      .then(function (data) {
+        $updateBtn.textContent = "Update";
+        $updateBtn.classList.remove("updating");
+        if (data.alreadyCurrent) {
+          setAdminStatus('<span class="status-success">Already up to date</span>');
+          showToast("Already up to date", "info");
+          setAdminBusy(false);
+          return false; // no updates
+        }
+        var html = '<span class="status-success">' + esc(data.commits + " commit(s) pulled") + '</span>';
+        if (data.commitMessages && data.commitMessages.length > 0) {
+          html += '<ul class="update-commits">';
+          for (var i = 0; i < data.commitMessages.length; i++) {
+            html += "<li>" + esc(data.commitMessages[i]) + "</li>";
+          }
+          html += "</ul>";
+        }
+        setAdminStatus(html);
+        showToast(data.commits + " commit(s) pulled. Restart to apply.", "success");
+        setAdminBusy(false);
+        return true; // had updates
+      })
+      .catch(function (err) {
+        $updateBtn.textContent = "Update";
+        $updateBtn.classList.remove("updating");
+        setAdminStatus('<span class="status-error">Update failed: ' + esc(err.message) + '</span>');
+        showToast("Update failed: " + err.message, "error");
+        setAdminBusy(false);
+        return false;
+      });
+  }
+
+  function doRestart() {
+    if (adminBusy) return;
+    setAdminBusy(true);
+    $restartBtn.textContent = "Restarting\u2026";
+    $restartBtn.classList.add("restarting");
+    setAdminStatus('<span class="status-info">Restarting Miranda\u2026</span>');
+
+    // Stop auto-refresh during restart
+    stopAutoRefresh();
+
+    api("POST", "/api/restart")
+      .catch(function () {
+        // Expected — server shuts down, fetch may fail
+      })
+      .then(function () {
+        // Poll for reconnection
+        return pollReconnect();
+      })
+      .then(function () {
+        $restartBtn.textContent = "Restart";
+        $restartBtn.classList.remove("restarting");
+        setAdminStatus('<span class="status-success">Back online</span>');
+        showToast("Miranda is back online", "success");
+        setAdminBusy(false);
+        refreshAll();
+        startAutoRefresh();
+      })
+      .catch(function (err) {
+        $restartBtn.textContent = "Restart";
+        $restartBtn.classList.remove("restarting");
+        setAdminStatus('<span class="status-error">' + esc(err.message) + '</span>');
+        showToast(err.message, "error");
+        setAdminBusy(false);
+        startAutoRefresh();
+      });
+  }
+
+  function pollReconnect() {
+    var POLL_INTERVAL = 2000; // 2 seconds
+    var TIMEOUT = 30000; // 30 seconds
+    var startTime = Date.now();
+
+    return new Promise(function (resolve, reject) {
+      function check() {
+        if (Date.now() - startTime > TIMEOUT) {
+          reject(new Error("Miranda did not come back within 30s"));
+          return;
+        }
+        setAdminStatus('<span class="status-info">Reconnecting\u2026</span>');
+        fetch("/api/sessions", {
+          headers: { "x-telegram-init-data": getInitData() },
+        })
+          .then(function (res) {
+            if (res.ok) {
+              resolve();
+            } else {
+              setTimeout(check, POLL_INTERVAL);
+            }
+          })
+          .catch(function () {
+            setTimeout(check, POLL_INTERVAL);
+          });
+      }
+      // Wait a bit before first check — server needs time to shut down
+      setTimeout(check, POLL_INTERVAL);
+    });
+  }
+
+  $updateBtn.addEventListener("click", function () {
+    doSelfUpdate();
+  });
+
+  $restartBtn.addEventListener("click", function () {
+    var sessionCount = sessions.length;
+    var msg = "Restart Miranda?";
+    if (sessionCount > 0) {
+      msg += "\n\n" + sessionCount + " active session(s) will be terminated.";
+    }
+    if (!confirm(msg)) return;
+    doRestart();
+  });
+
+  $updateRestartBtn.addEventListener("click", function () {
+    var sessionCount = sessions.length;
+    var msg = "Update and restart Miranda?";
+    if (sessionCount > 0) {
+      msg += "\n\n" + sessionCount + " active session(s) will be terminated.";
+    }
+    if (!confirm(msg)) return;
+    doSelfUpdate().then(function (hadUpdates) {
+      // Restart regardless — user explicitly asked for update & restart
+      doRestart();
+    });
   });
 
   // ---------------------------------------------------------------------------

--- a/public/index.html
+++ b/public/index.html
@@ -44,6 +44,20 @@
   </div>
 </section>
 
+<section class="section" id="admin-section">
+  <div class="section-header">
+    <span class="section-title">Admin</span>
+  </div>
+  <div class="admin-card">
+    <div class="admin-buttons">
+      <button class="btn btn-secondary" id="update-btn">Update</button>
+      <button class="btn btn-danger" id="restart-btn">Restart</button>
+      <button class="btn btn-primary" id="update-restart-btn">Update &amp; Restart</button>
+    </div>
+    <div class="admin-status" id="admin-status"></div>
+  </div>
+</section>
+
 <!-- Comment Modal -->
 <div class="modal-overlay" id="comment-modal">
   <div class="modal-content">

--- a/public/style.css
+++ b/public/style.css
@@ -511,6 +511,65 @@ a.pr-status:active {
   100% { width: 100%; opacity: 0; }
 }
 
+/* --- Admin Section --- */
+
+.admin-card {
+  background: var(--tg-theme-secondary-bg-color);
+  border-radius: var(--radius);
+  padding: var(--gap);
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.admin-buttons {
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+.admin-status {
+  font-size: 13px;
+  line-height: 1.5;
+  color: var(--tg-theme-hint-color);
+}
+
+.admin-status:empty {
+  display: none;
+}
+
+.admin-status .update-commits {
+  margin-top: 4px;
+  padding: 6px 8px;
+  background: rgba(255, 255, 255, 0.04);
+  border-radius: var(--radius-sm);
+  font-size: 12px;
+  color: var(--tg-theme-text-color);
+}
+
+.admin-status .update-commits li {
+  list-style: none;
+  padding: 1px 0;
+}
+
+.admin-status .status-success {
+  color: #30d158;
+}
+
+.admin-status .status-error {
+  color: var(--tg-theme-destructive-text-color);
+}
+
+.admin-status .status-info {
+  color: var(--tg-theme-hint-color);
+}
+
+.btn.updating,
+.btn.restarting {
+  opacity: 0.6;
+  cursor: wait;
+}
+
 /* --- Scrollbar (webkit) --- */
 
 ::-webkit-scrollbar {

--- a/src/index.ts
+++ b/src/index.ts
@@ -17,6 +17,7 @@ import {
   clearRestartChatId,
 } from "./state/sessions.js";
 import { startApiServer, stopApiServer } from "./api/server.js";
+import { setApiShutdownFn } from "./api/routes.js";
 
 // Validate configuration
 validateConfig();
@@ -69,6 +70,9 @@ bot.use(async (ctx, next) => {
 
 // Register command handlers (pass shutdown function for /restart)
 registerCommands(bot, gracefulShutdown);
+
+// Register shutdown function for API /restart endpoint
+setApiShutdownFn(gracefulShutdown);
 
 // Callback query handler for inline keyboards
 bot.on("callback_query:data", async (ctx) => {


### PR DESCRIPTION
Closes #90

## Summary

Adds Update and Restart controls to the Miranda Control Center Mini App, enabling deployment without switching to Telegram commands.

### Backend

- **POST /api/selfupdate** — Reuses `selfUpdate()` from scanner.ts. Returns `{ commits, commitMessages, alreadyCurrent }`.
- **POST /api/restart** — Sends `{ ok: true }` response, then calls `gracefulShutdown()` after 500ms delay so the response reaches the client. Process manager (systemd/PM2) handles the actual restart.
- `setApiShutdownFn()` setter pattern (same as `setBot()` in agent/events.ts) avoids circular imports.

### Frontend

- **Admin section** in the control center with three buttons:
 - **Update** — Pulls latest, builds. Shows commit count and messages on success, "Already up to date" when current, error details on failure.
 - **Restart** — Confirmation dialog showing active session count. After triggering, polls `GET /api/sessions` every 2s until Miranda responds again (30s timeout). Shows "Reconnecting..." then "Back online" flow.
 - **Update & Restart** — Combined flow: update first, then restart regardless of whether there were new commits.
- Busy lock prevents concurrent admin operations (all three buttons disable together).
- Auto-refresh paused during restart to avoid error noise.

### Edge cases handled

- Server going down during restart: fetch errors caught, "Reconnecting..." shown, retry loop
- Build errors from selfupdate: error shown to user, no auto-restart
- Restart without update: works fine, just restarts current code
- 30s reconnection timeout: error shown if Miranda does not come back