### PR TITLE
Add live session log streaming via SSE to control center

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -45,6 +45,10 @@
 
   var REFRESH_INTERVAL = 10000; // 10 seconds
 
+  // Log panel state: { taskId: { es: EventSource, panel: Element, autoScroll: bool } }
+  var logStreams = {};
+  var MAX_LOG_LINES = 200;
+
   // ---------------------------------------------------------------------------
   // DOM refs
   // ---------------------------------------------------------------------------
@@ -139,20 +143,29 @@
   // ---------------------------------------------------------------------------
 
   function renderSessions() {
+    // Close log streams for sessions that no longer exist
+    var currentTaskIds = {};
+    for (var si = 0; si < sessions.length; si++) {
+      currentTaskIds[sessions[si].taskId] = true;
+    }
+    for (var tid in logStreams) {
+      if (!currentTaskIds[tid]) {
+        closeLogStream(tid);
+      }
+    }
     if (sessions.length === 0) {
       $sessionsList.innerHTML = '<div class="empty-state">No active sessions</div>';
       $sessionsCount.style.display = "none";
       return;
     }
-
     $sessionsCount.textContent = sessions.length;
     $sessionsCount.style.display = "";
-
     var html = "";
     for (var i = 0; i < sessions.length; i++) {
       var s = sessions[i];
       var statusLabel = s.status.replace("_", " ");
-      html += '<div class="session-card">';
+      var isLogOpen = !!logStreams[s.taskId];
+      html += '<div class="session-card" data-session-task="' + escAttr(s.taskId) + '">';
       html += '<div class="session-top">';
       html += '<div class="session-info">';
       html += '<div class="session-task">' + esc(s.taskId) + "</div>";
@@ -162,11 +175,16 @@
       html += "<span>" + esc(s.skill) + "</span>";
       html += "<span>" + esc(s.elapsed) + "</span>";
       html += "</div></div>";
+      html += '<div class="session-card-actions">';
+      html +=
+        '<button class="log-toggle' + (isLogOpen ? ' active' : '') + '" data-task="' +
+        escAttr(s.taskId) +
+        '">Logs</button>';
       html +=
         '<button class="btn btn-danger btn-stop" data-task="' +
         escAttr(s.taskId) +
         '">Stop</button>';
-      html += "</div>";
+      html += "</div></div>";
       if (s.pendingQuestion) {
         var q = s.pendingQuestion.questions;
         for (var j = 0; j < q.length; j++) {
@@ -174,14 +192,28 @@
             '<div class="session-question">' + esc(q[j]) + "</div>";
         }
       }
+      // Placeholder for log panel (re-attached below if open)
+      html += '<div class="log-panel-slot" data-log-slot="' + escAttr(s.taskId) + '"></div>';
       html += "</div>";
     }
     $sessionsList.innerHTML = html;
-
-    // Attach stop handlers
     var stopBtns = $sessionsList.querySelectorAll(".btn-stop");
     for (var k = 0; k < stopBtns.length; k++) {
       stopBtns[k].addEventListener("click", handleStopClick);
+    }
+
+    // Attach log toggle handlers
+    var logBtns = $sessionsList.querySelectorAll(".log-toggle");
+    for (var l = 0; l < logBtns.length; l++) {
+      logBtns[l].addEventListener("click", handleLogToggle);
+    }
+
+    // Re-attach existing log panels
+    for (var taskId in logStreams) {
+      var slot = $sessionsList.querySelector('[data-log-slot="' + escAttr(taskId) + '"]');
+      if (slot && logStreams[taskId].panel) {
+        slot.appendChild(logStreams[taskId].panel);
+      }
     }
   }
 
@@ -197,6 +229,121 @@
       .catch(function (err) {
         showToast(err.message, "error");
       });
+  }
+
+  // ---------------------------------------------------------------------------
+  // Log Panel
+  // ---------------------------------------------------------------------------
+
+  function handleLogToggle(e) {
+    var taskId = e.currentTarget.getAttribute("data-task");
+    if (!taskId) return;
+    if (logStreams[taskId]) {
+      closeLogStream(taskId);
+      renderSessions();
+    } else {
+      openLogStream(taskId);
+      renderSessions();
+    }
+  }
+
+  function openLogStream(taskId) {
+    if (logStreams[taskId]) return;
+
+    var panel = document.createElement("div");
+    panel.className = "log-panel";
+
+    var initData = getInitData();
+    var url = "/api/sessions/" + encodeURIComponent(taskId) + "/logs?initData=" + encodeURIComponent(initData);
+    var es = new EventSource(url);
+    var state = { es: es, panel: panel, autoScroll: true };
+    logStreams[taskId] = state;
+    panel.addEventListener("scroll", function () {
+      // If user scrolled up from bottom, pause auto-scroll
+      var atBottom = panel.scrollHeight - panel.scrollTop - panel.clientHeight < 30;
+      state.autoScroll = atBottom;
+    });
+
+
+    es.onmessage = function (evt) {
+      try {
+        var event = JSON.parse(evt.data);
+        appendLogLine(panel, state, event);
+      } catch (err) {
+        // Ignore parse errors
+      }
+    };
+
+    es.onerror = function () {
+      // EventSource auto-reconnects; on permanent close, clean up
+      if (es.readyState === EventSource.CLOSED) {
+        closeLogStream(taskId);
+      }
+    };
+  }
+
+  function closeLogStream(taskId) {
+    var stream = logStreams[taskId];
+    if (!stream) return;
+    stream.es.close();
+    if (stream.panel.parentNode) {
+      stream.panel.parentNode.removeChild(stream.panel);
+    }
+    delete logStreams[taskId];
+  }
+
+  function appendLogLine(panel, state, event) {
+    var line = document.createElement("div");
+    line.className = "log-line";
+
+    var timeSpan = document.createElement("span");
+    timeSpan.className = "log-time";
+    timeSpan.textContent = event.time || "";
+    line.appendChild(timeSpan);
+
+    var contentSpan = document.createElement("span");
+
+    switch (event.type) {
+      case "tool_start":
+        contentSpan.className = "log-tool";
+        contentSpan.textContent = "\u25B6 " + (event.tool || "tool");
+        break;
+      case "tool_end":
+        contentSpan.className = "log-tool";
+        contentSpan.textContent = "\u2713 " + (event.tool || "tool");
+        break;
+      case "text":
+        contentSpan.className = "log-text";
+        contentSpan.textContent = event.content || "";
+        break;
+      case "question":
+        contentSpan.className = "log-question";
+        contentSpan.textContent = "\u23F8 Waiting: " + (event.content || "");
+        break;
+      case "complete":
+        contentSpan.className = "log-complete";
+        contentSpan.textContent = "\u2713 Session complete";
+        break;
+      case "error":
+        contentSpan.className = "log-error";
+        contentSpan.textContent = "\u2717 " + (event.content || "Error");
+        break;
+      default:
+        contentSpan.textContent = event.type + ": " + (event.content || "");
+    }
+
+    line.appendChild(contentSpan);
+    panel.appendChild(line);
+
+    // Trim old lines
+    while (panel.children.length > MAX_LOG_LINES) {
+      panel.removeChild(panel.firstChild);
+    }
+
+    // Auto-scroll
+    if (state.autoScroll) {
+      panel.scrollTop = panel.scrollHeight;
+    }
   }
 
   // ---------------------------------------------------------------------------

--- a/public/style.css
+++ b/public/style.css
@@ -213,6 +213,13 @@ html, body {
   justify-content: space-between;
 }
 
+.session-card-actions {
+  display: flex;
+  gap: 6px;
+  align-items: center;
+  flex-shrink: 0;
+}
+
 .session-info {
   display: flex;
   flex-direction: column;
@@ -622,4 +629,74 @@ a.pr-status:active {
 ::-webkit-scrollbar-thumb {
   background: rgba(255, 255, 255, 0.15);
   border-radius: 2px;
+}
+
+/* --- Log Panel --- */
+
+.log-panel {
+  background: #111113;
+  border-radius: var(--radius-sm);
+  max-height: 300px;
+  overflow-y: auto;
+  padding: 8px 10px;
+  font-family: "SF Mono", "Menlo", "Monaco", "Courier New", monospace;
+  font-size: 12px;
+  line-height: 1.6;
+  margin-top: 8px;
+}
+
+.log-line {
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
+.log-line .log-time {
+  color: var(--tg-theme-hint-color);
+  margin-right: 6px;
+  user-select: none;
+}
+
+.log-tool {
+  color: #64d2ff;
+  font-weight: 600;
+}
+
+.log-error {
+  color: #ff453a;
+}
+
+.log-question {
+  color: #ffd60a;
+  background: rgba(255, 214, 10, 0.08);
+  padding: 2px 4px;
+  border-radius: 3px;
+}
+
+.log-complete {
+  color: #30d158;
+  font-weight: 600;
+}
+
+.log-text {
+  color: var(--tg-theme-text-color);
+}
+
+.log-toggle {
+  background: none;
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  color: var(--tg-theme-hint-color);
+  font-size: 12px;
+  padding: 4px 10px;
+  border-radius: var(--radius-sm);
+  cursor: pointer;
+  transition: opacity 0.15s;
+}
+
+.log-toggle:active {
+  opacity: 0.7;
+}
+
+.log-toggle.active {
+  background: rgba(255, 255, 255, 0.08);
+  color: var(--tg-theme-text-color);
 }

--- a/src/api/logs.ts
+++ b/src/api/logs.ts
@@ -1,0 +1,173 @@
+import type { ServerResponse } from "node:http";
+
+// ============================================================================
+// SSE Log Streaming — Per-session subscriber management with ring buffer
+// ============================================================================
+
+export interface LogEvent {
+  type: "tool_start" | "tool_end" | "text" | "question" | "complete" | "error";
+  tool?: string;
+  content?: string;
+  time: string; // HH:MM:SS
+}
+
+const BUFFER_SIZE = 50;
+
+/** Per-session subscriber set */
+const subscribers = new Map<string, Set<ServerResponse>>();
+
+/** Ring buffer of last N events per session for backfill on connect */
+const eventBuffers = new Map<string, LogEvent[]>();
+
+/** Text delta throttle state per session */
+interface ThrottleState {
+  pending: string;
+  timer: ReturnType<typeof setTimeout> | null;
+}
+const textThrottles = new Map<string, ThrottleState>();
+
+const TEXT_THROTTLE_MS = 200;
+
+/**
+ * Format current time as HH:MM:SS.
+ */
+function timeNow(): string {
+  const d = new Date();
+  return (
+    String(d.getHours()).padStart(2, "0") +
+    ":" +
+    String(d.getMinutes()).padStart(2, "0") +
+    ":" +
+    String(d.getSeconds()).padStart(2, "0")
+  );
+}
+
+/**
+ * Write a single SSE event to a response stream.
+ */
+function writeSSE(res: ServerResponse, event: LogEvent): void {
+  if (res.destroyed) return;
+  res.write(`data: ${JSON.stringify(event)}\n\n`);
+}
+
+/**
+ * Append event to ring buffer for a session.
+ */
+function bufferEvent(sessionId: string, event: LogEvent): void {
+  let buf = eventBuffers.get(sessionId);
+  if (!buf) {
+    buf = [];
+    eventBuffers.set(sessionId, buf);
+  }
+  buf.push(event);
+  if (buf.length > BUFFER_SIZE) {
+    buf.shift();
+  }
+}
+
+/**
+ * Flush any pending throttled text for a session immediately.
+ */
+function flushTextThrottle(sessionId: string): void {
+  const state = textThrottles.get(sessionId);
+  if (!state) return;
+  if (state.timer) {
+    clearTimeout(state.timer);
+    state.timer = null;
+  }
+  if (state.pending) {
+    const event: LogEvent = { type: "text", content: state.pending, time: timeNow() };
+    state.pending = "";
+    bufferEvent(sessionId, event);
+    const subs = subscribers.get(sessionId);
+    if (subs) {
+      for (const res of subs) {
+        writeSSE(res, event);
+      }
+    }
+  }
+  textThrottles.delete(sessionId);
+}
+
+/**
+ * Called from handleAgentEvent to fan-out log events to SSE subscribers.
+ * Text deltas are throttled: batched and emitted at most once per 200ms.
+ */
+export function emitLogEvent(sessionId: string, event: LogEvent): void {
+  // Text deltas get throttled
+  if (event.type === "text") {
+    let state = textThrottles.get(sessionId);
+    if (!state) {
+      state = { pending: "", timer: null };
+      textThrottles.set(sessionId, state);
+    }
+    state.pending += event.content ?? "";
+    if (!state.timer) {
+      state.timer = setTimeout(() => {
+        flushTextThrottle(sessionId);
+      }, TEXT_THROTTLE_MS);
+    }
+    return;
+  }
+
+  // Non-text events: flush any pending text first, then emit immediately
+  flushTextThrottle(sessionId);
+
+  bufferEvent(sessionId, event);
+  const subs = subscribers.get(sessionId);
+  if (!subs) return;
+  for (const res of subs) {
+    writeSSE(res, event);
+  }
+}
+
+/**
+ * Subscribe a response to a session's log stream.
+ * Sends backfill events from ring buffer immediately.
+ */
+export function subscribe(sessionId: string, res: ServerResponse): void {
+  let subs = subscribers.get(sessionId);
+  if (!subs) {
+    subs = new Set();
+    subscribers.set(sessionId, subs);
+  }
+  subs.add(res);
+
+  // Send backfill
+  const buf = eventBuffers.get(sessionId);
+  if (buf) {
+    for (const event of buf) {
+      writeSSE(res, event);
+    }
+  }
+}
+
+/**
+ * Unsubscribe a response (on connection close).
+ */
+export function unsubscribe(sessionId: string, res: ServerResponse): void {
+  const subs = subscribers.get(sessionId);
+  if (!subs) return;
+  subs.delete(res);
+  if (subs.size === 0) {
+    subscribers.delete(sessionId);
+  }
+}
+
+/**
+ * Clean up when session ends — flush pending text, notify subscribers, remove state.
+ */
+export function closeSession(sessionId: string): void {
+  flushTextThrottle(sessionId);
+  textThrottles.delete(sessionId);
+  eventBuffers.delete(sessionId);
+  const subs = subscribers.get(sessionId);
+  if (subs) {
+    for (const res of subs) {
+      if (!res.destroyed) {
+        res.end();
+      }
+    }
+    subscribers.delete(sessionId);
+  }
+}


### PR DESCRIPTION
Closes #93

## Summary

Adds real-time log streaming to the Miranda control center. Tapping an active session's **Logs** button opens a live log panel showing what the agent is doing — tool calls, text output, status changes — all streamed via Server-Sent Events.

### Backend

- **New `src/api/logs.ts`**: SSE subscriber management with per-session ring buffer (last 50 events for backfill on connect) and text delta throttling (batch at most once per 200ms)
- **`src/agent/events.ts`**: Fan-out from `handleAgentEvent()` to SSE subscribers for relevant RPC events (tool start/end, text deltas, UI requests, agent end, errors). Skips thinking_delta, toolcall_delta, and other noisy events.
- **`src/api/routes.ts`**: `GET /api/sessions/:id/logs?initData=...` SSE endpoint with query param auth (EventSource cannot set custom headers)

### Frontend

- **`public/app.js`**: Logs toggle button on each session card; opens EventSource connection; formats events as readable log lines; auto-scroll with pause on manual scroll-up; max 200 DOM lines trimmed from top; log panels preserved across 10s refresh cycles; EventSource closed on collapse
- **`public/style.css`**: Dark monospace log panel, color-coded event types (tool=cyan, error=red, question=amber, complete=green)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added per-session log streaming with toggle button to view real-time activity.
  * Logs display events with timestamps including tool execution, messages, errors, and completions.
  * Auto-scroll behavior respects user scroll position and resumes when scrolled to bottom.
  * Log history automatically trimmed to maintain performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->