### PR TITLE
Cross-project Pull Requests dashboard

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -34,13 +34,13 @@
   </div>
 </section>
 
-<section class="section" id="prs-section" style="display:none">
+<section class="section" id="all-prs-section">
   <div class="section-header">
     <span class="section-title">Pull Requests</span>
-    <span class="section-badge" id="prs-count" style="display:none">0</span>
+    <span class="section-badge" id="all-prs-count" style="display:none">0</span>
   </div>
   <div class="section-body">
-    <div class="card-list" id="prs-list">
+    <div class="card-list" id="all-prs-list">
       <div class="empty-state">No open PRs</div>
     </div>
   </div>

--- a/public/style.css
+++ b/public/style.css
@@ -443,13 +443,32 @@ a.pr-status:active {
   flex-shrink: 0;
 }
 
-.pr-card-issue {
-  font-size: 13px;
-  color: var(--tg-theme-hint-color);
+.pr-card-project {
+  font-size: 10px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  padding: 2px 6px;
+  border-radius: 4px;
+  background: rgba(10, 132, 255, 0.15);
+  color: var(--tg-theme-link-color);
+  flex-shrink: 0;
+  white-space: nowrap;
+}
+
+.pr-card-title {
+  font-size: 14px;
+  font-weight: 600;
   min-width: 0;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
+  flex: 1;
+}
+
+.pr-card-linked {
+  font-size: 12px;
+  color: var(--tg-theme-hint-color);
 }
 
 .pr-card-status {


### PR DESCRIPTION
Closes #96

## Summary

Add a top-level cross-project Pull Requests section to the control center that shows all open Miranda-created PRs across all projects in one view.

### Backend
- New `GET /api/prs` endpoint that loops all projects, fetches PRs per-repo in parallel, filters to `issue/` branches, and includes enrichment (CI status, CodeRabbit review) inline
- Reuses existing `getOpenPRs()`, `getRepoInfo()`, `getPREnrichment()` with best-effort error handling per project

### Frontend
- New always-visible `#all-prs-section` between project selector and sessions section
- Each PR card shows: project badge, PR number (clickable), title, linked issues, merge status, CI/CodeRabbit indicators
- Action buttons (Merge, Comment, Notes) carry `data-project` attribute for cross-project operations
- Comment modal updated to support `commentProject` variable (fallback to `selectedProject`)
- Old per-project PR section removed from HTML and JS
- Client-side enrichment caching removed (enrichment now comes from server in single API call)
- Section is collapsible with localStorage persistence

### Styling
- `.pr-card-project` — uppercase project badge with accent color
- `.pr-card-title` — truncated with ellipsis
- `.pr-card-linked` — hint-colored linked issue references

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added cross-project PR tracking to display pull requests from all projects in a unified view.

* **Refactor**
  * Simplified PR data loading and display architecture.
  * Updated PR styling to include project context and improved visual hierarchy.
  * PR section now visible by default with project badges for clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->