### PR TITLE
Add close issue button on issue cards in Mini App

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -534,6 +534,13 @@
       startBtn.setAttribute("data-issue", issue.number);
       startBtn.addEventListener("click", handleStartClick);
       actions.appendChild(startBtn);
+
+      var closeBtn = document.createElement("button");
+      closeBtn.className = "btn btn-danger";
+      closeBtn.textContent = "Close";
+      closeBtn.setAttribute("data-issue", issue.number);
+      closeBtn.addEventListener("click", handleCloseClick);
+      actions.appendChild(closeBtn);
     }
 
 
@@ -686,6 +693,23 @@
       .then(function () {
         showToast("Issue #" + issueNum + " started", "success");
         return loadSessions();
+      })
+      .catch(function (err) {
+        btn.disabled = false;
+        showToast(err.message, "error");
+      });
+  }
+
+  function handleCloseClick(e) {
+    var issueNum = e.currentTarget.getAttribute("data-issue");
+    if (!issueNum || !selectedProject) return;
+    if (!confirm("Close issue #" + issueNum + "?")) return;
+    var btn = e.currentTarget;
+    btn.disabled = true;
+    api("POST", "/api/projects/" + encodeURIComponent(selectedProject) + "/issues/" + issueNum + "/close")
+      .then(function () {
+        showToast("Issue #" + issueNum + " closed", "success");
+        return loadProjectData();
       })
       .catch(function (err) {
         btn.disabled = false;

--- a/src/api/github.ts
+++ b/src/api/github.ts
@@ -275,6 +275,29 @@ export async function mergePR(
 }
 
 /**
+ * Close a GitHub issue.
+ */
+export async function closeIssue(
+  owner: string,
+  repo: string,
+  issueNumber: number
+): Promise<{ closed: boolean; message: string }> {
+  try {
+    await githubFetch<{ state: string }>(
+      `/repos/${owner}/${repo}/issues/${issueNumber}`,
+      {
+        method: "PATCH",
+        body: { state: "closed" },
+      }
+    );
+    return { closed: true, message: "Issue closed" };
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    return { closed: false, message };
+  }
+}
+
+/**
  * Post a comment on a PR (or issue — same API).
  */
 export async function commentOnPR(


### PR DESCRIPTION
Closes #103

## Summary

Adds a "Close" button to each issue card in the Telegram Mini App, allowing users to close GitHub issues directly from the dashboard.

### Changes

**Backend**:
- `src/api/github.ts`: New `closeIssue(owner, repo, issueNumber)` function using GitHub PATCH endpoint with `{"state": "closed"}`
- `src/api/routes.ts`: New `POST /api/projects/:name/issues/:number/close` route handler

**Frontend**:
- `public/app.js`: Close button in `renderIssueNode()` alongside Start button
 - Confirmation dialog before closing
 - Button disabled during request (prevents double-click)
 - Toast notification on success/error
 - Issue list refreshes after close
 - Button hidden when issue has active session
 - Uses existing `.btn-danger` styling

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a Close button to each issue, enabling users to close issues directly from the application with one click.
  * Implemented confirmation prompt before closing to prevent accidental actions.
  * Displays success and error notifications upon completion of the close operation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->