### PR TITLE
Fix scheduler Execute Now button overflow on mobile

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -71,7 +71,7 @@
           <input type="checkbox" id="scheduler-toggle">
           <span class="toggle-text">Auto-start issues when deps resolve</span>
         </label>
-        <button class="btn btn-primary btn-sm" id="scheduler-trigger-btn">Execute Now</button>
+        <button class="btn btn-primary" id="scheduler-trigger-btn">Execute Now</button>
       </div>
       <div class="scheduler-status" id="scheduler-status"></div>
     </div>

--- a/public/style.css
+++ b/public/style.css
@@ -857,6 +857,7 @@ a.pr-status:active {
   align-items: center;
   justify-content: space-between;
   gap: 8px;
+  flex-wrap: wrap;
 }
 
 .toggle-label {
@@ -866,6 +867,19 @@ a.pr-status:active {
   cursor: pointer;
   font-size: 13px;
   color: var(--tg-theme-text-color);
+  min-width: 0;
+}
+
+.toggle-text {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  min-width: 0;
+}
+
+#scheduler-trigger-btn {
+  flex-shrink: 0;
+  white-space: nowrap;
 }
 
 .toggle-label input[type="checkbox"] {


### PR DESCRIPTION
Closes #104

## Summary

The "Execute Now" button in the scheduler controls had class `btn-sm`, which forces `width: 36px; height: 36px; padding: 0` -- dimensions designed for icon-only buttons (`+`, `-`). A text button cannot fit in 36px wide, causing overflow on mobile.

### Changes

**`public/index.html`**
- Remove `btn-sm` from `#scheduler-trigger-btn`, keeping `btn btn-primary` so it auto-sizes with standard padding (`6px 12px`)

**`public/style.css`**
- Add `flex-wrap: wrap` to `.scheduler-controls` so toggle + button stack vertically on very narrow screens (<320px)
- Add `min-width: 0` to `.toggle-label` so it can shrink to make room for the button
- Add `.toggle-text` styles with `text-overflow: ellipsis` for graceful label truncation
- Add `#scheduler-trigger-btn` with `flex-shrink: 0; white-space: nowrap` to prevent button text compression

### What is preserved
- `btn-sm` class unchanged -- still used correctly on `+`, `-`, and `Plan` icon buttons
- Both button states ("Execute Now" and "Running...") fit without overflow
- No visual regression on larger screens -- button simply uses standard padding instead of forced 36px square

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Increased scheduler trigger button size for improved visibility
  * Enhanced text wrapping and truncation for UI elements to prevent overflow
  * Improved layout flexibility for scheduler controls and status sections

<!-- end of auto-generated comment: release notes by coderabbit.ai -->