### PR TITLE
Make ba/sg/wm init idempotent in cloneAndInit and add missing wm init

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -130,10 +130,10 @@ Clones a GitHub repository and initializes development tools in one step.
 
 **What happens:**
 1. Clones to `$PROJECTS_DIR/<repo-name>` via `gh repo clone`
-2. Runs `sg init` (superego)
-
+2. Runs `ba init`, `sg init`, `wm init` (skips any already initialized)
 **Notes:**
 - GitHub only (uses `gh` CLI)
+- Skips tool init when directory already exists (`.ba/`, `.superego/`, `.wm/`)
 - Reports partial success if clone works but init fails
 - 10-minute clone timeout, 30-second per-tool init timeout
 

--- a/src/bot/commands.ts
+++ b/src/bot/commands.ts
@@ -1337,13 +1337,14 @@ Examples:
       { parse_mode: "Markdown" }
     );
   } else {
-    await ctx.reply(
-      `Project \`${result.repoName}\` ready
-
-Path: \`${result.projectPath}\`
-Initialized: ba, sg, wm`,
-      { parse_mode: "Markdown" }
-    );
+    const parts = [`Project \`${result.repoName}\` ready\n\nPath: \`${result.projectPath}\``];
+    if (result.initialized && result.initialized.length > 0) {
+      parts.push(`Initialized: ${result.initialized.join(", ")}`);
+    }
+    if (result.skipped && result.skipped.length > 0) {
+      parts.push(`Already present: ${result.skipped.join(", ")}`);
+    }
+    await ctx.reply(parts.join("\n"), { parse_mode: "Markdown" });
   }
 }
 

--- a/src/projects/clone.ts
+++ b/src/projects/clone.ts
@@ -73,10 +73,14 @@ export interface CloneResult {
   projectPath?: string;
   repoName?: string;
   error?: string;
+  /** Tools that were freshly initialized */
+  initialized?: string[];
+  /** Tools that were already present and skipped */
+  skipped?: string[];
 }
 
 /**
- * Clone a repository and initialize ba and sg.
+ * Clone a repository and initialize ba, sg, and wm.
  *
  * **GitHub Only**: This function only supports GitHub repositories.
  * Uses `gh repo clone` which requires GitHub URLs.
@@ -136,32 +140,51 @@ export async function cloneAndInit(repoRef: string): Promise<CloneResult> {
       error: `Project directory is not accessible after clone: ${projectPath}`,
     };
   }
-  // Initialize tools with timeouts
-  const initErrors: string[] = [];
+
+  // Initialize tools, skipping any already present
+  const tools = [
+    { name: "ba", dir: ".ba" },
+    { name: "sg", dir: ".superego" },
+    { name: "wm", dir: ".wm" },
+  ];
   const initTimeout = 30000; // 30 second timeout for each init
+  const initErrors: string[] = [];
+  const initialized: string[] = [];
+  const skipped: string[] = [];
 
-  try {
-    await execFileAsync("ba", ["init"], { cwd: projectPath, timeout: initTimeout });
-  } catch (error) {
-    const message = error instanceof Error ? error.message : String(error);
-    initErrors.push(`ba init failed: ${message}`);
+  for (const tool of tools) {
+    const toolDir = join(projectPath, tool.dir);
+    let alreadyExists = false;
+    try {
+      await access(toolDir, constants.F_OK);
+      alreadyExists = true;
+    } catch {
+      // Directory doesn't exist - needs init
+    }
+
+    if (alreadyExists) {
+      skipped.push(tool.name);
+      continue;
+    }
+
+    try {
+      await execFileAsync(tool.name, ["init"], { cwd: projectPath, timeout: initTimeout });
+      initialized.push(tool.name);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      initErrors.push(`${tool.name} init failed: ${message}`);
+    }
   }
-
-  try {
-    await execFileAsync("sg", ["init"], { cwd: projectPath, timeout: initTimeout });
-  } catch (error) {
-    const message = error instanceof Error ? error.message : String(error);
-    initErrors.push(`sg init failed: ${message}`);
-  }
-
   if (initErrors.length > 0) {
     return {
       success: true,
       projectPath,
       repoName: parsed.repo,
+      initialized,
+      skipped,
       error: `Cloned but init had issues:\n${initErrors.join("\n")}`,
     };
   }
 
-  return { success: true, projectPath, repoName: parsed.repo };
+  return { success: true, projectPath, repoName: parsed.repo, initialized, skipped };
 }


### PR DESCRIPTION
Closes #109

## Summary

Makes `cloneAndInit()` idempotent with respect to tool initialization and adds the missing `wm init` call.

### Changes

- **Check before init**: Before calling each tool init, checks if its directory already exists (`.ba/`, `.superego/`, `.wm/`); skips init if present
- **Add wm init**: `wm init` was never called despite the success message claiming it was initialized
- **Better feedback**: `CloneResult` now includes `initialized` and `skipped` arrays so the Telegram message accurately reports what happened
- **Cleaner structure**: Replaced three separate try/catch blocks with a loop over a tools config array
- **Updated docs**: CLAUDE.md now documents all three tools and the skip behavior

### Behavior

| Scenario | Before | After |
|----------|--------|-------|
| Fresh clone | ba+sg init, wm missing | ba+sg+wm all init |
| All tools present | Error/warning from ba+sg | Silent skip, success |
| Some tools present | Error from present ones | Init missing, skip present |
| Success message | Always "Initialized: ba, sg, wm" | Shows which were initialized vs already present |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Project initialization now automatically detects and skips directories that are already initialized.
  * Enhanced feedback messages clearly distinguish between newly initialized components and those already present, providing better visibility into setup status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->