### PR TITLE
Factory view: add Close button for issues without PRs

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -921,6 +921,13 @@
                 joinBtn.addEventListener('click', handleJoinClick);
                 actions.appendChild(joinBtn);
               }
+
+              var closeBtn = document.createElement('button');
+              closeBtn.className = 'btn btn-danger btn-compact';
+              closeBtn.textContent = 'Close';
+              closeBtn.setAttribute('data-issue', issue.number);
+              closeBtn.addEventListener('click', handleCloseClick);
+              actions.appendChild(closeBtn);
             }
 
             var isQueued = queuedSet[issue.number];


### PR DESCRIPTION
Closes #115

## Summary

Adds a Close button to the factory pipeline view for issues that don't have an active session and don't have a PR, matching the behavior already present in the regular issue tree view.

**Changes:**
- `public/app.js` — Added Close button creation in `renderFactoryPipeline` within the no-PR, no-active-session branch (between Start/Join and Queue buttons)

**Button behavior:**
- Styled with `btn btn-danger btn-compact` (compact variant for factory view)
- Sets `data-issue` attribute and uses the existing `handleCloseClick` handler
- Only appears when no active task/join session (hidden during "In Progress" state)
- Not shown for issues with PRs (those already have Merge/Comment/Notes actions)
- No backend changes needed — reuses existing `POST /api/projects/:name/issues/:num/close` endpoint

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a Close button to issue action sets, allowing you to directly close issues from the issue view without requiring additional steps or navigation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->