### PR TITLE
heimdall-overmind: Pointer doc for memex-hosted Overmind crate

### DIFF
--- a/docs/OVERMIND.md
+++ b/docs/OVERMIND.md
@@ -1,0 +1,40 @@
+# Overmind
+
+The Overmind is the persistent agentic loop for the software factory — the judgment layer that gives meaning to mechanical state.
+
+## Location
+
+The Overmind lives in the memex workspace, not in Miranda:
+
+```
+memex/heimdall-overmind/
+├── Cargo.toml
+└── src/
+    ├── main.rs         # daemon loop: poll → diff → gate → reason → writeback
+    ├── diff.rs         # state diff: extract significant events from snapshots
+    ├── gate.rs         # significance gate: debounce, urgency bypass
+    ├── reasoning.rs    # multi-turn agentic loop via attractor (Opus 4.6)
+    ├── writeback.rs    # POST judgments to Miranda
+    ├── tools.rs        # 10 tools: GitHub reads, LanceDB search, effect emitters
+    ├── memory.rs       # 5 LanceDB tables with arrow schemas
+    └── types.rs        # SignificantEvent, Judgment, Evaluation, AttentionItem
+```
+
+## Miranda integration points
+
+| Endpoint | Direction | Purpose |
+|---|---|---|
+| `GET /api/portfolio/snapshot` | Overmind ← Miranda | Poll current state (localhost-only) |
+| `POST /api/portfolio/overmind` | Overmind → Miranda | Write back judgments (localhost-only) |
+| `POST /api/sessions/spawn` | Overmind → Miranda | Spawn agent sessions |
+
+## Running
+
+```sh
+cd memex
+GITHUB_TOKEN=... ANTHROPIC_API_KEY=... cargo run -p heimdall-overmind -- run --repo owner/name
+```
+
+## Spec
+
+See `PORTFOLIO_STATE_SPEC.md` §12.3 for the full Overmind specification.


### PR DESCRIPTION
## Summary

The Overmind daemon lives in the memex workspace (`heimdall-overmind/` crate), not in Miranda. This PR adds a pointer doc documenting:

- Where the code lives
- Miranda integration endpoints (snapshot read, writeback, spawn)
- How to run the daemon

The actual implementation is in [memex PR #1226](https://github.com/open-horizon-labs/memex/pull/1226).

Closes #119

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive documentation for the Overmind component, including its role as a persistent judgment loop, repository structure, Miranda integration endpoints, data flow, and running instructions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->