### PR TITLE
heimdall-surface: Replace hardcoded rgba with OKLCH temperature tokens

### DIFF
--- a/heimdall/src/app.css
+++ b/heimdall/src/app.css
@@ -15,6 +15,11 @@
 	--attention: oklch(62% 0.14 45);
 	--waiting: oklch(70% 0.04 250);
 
+	/* Temperature — region background tints */
+	--temperature-asking: oklch(82% 0.14 65 / 0.06);
+	--temperature-hot: oklch(75% 0.16 55 / 0.05);
+	--temperature-warm: oklch(80% 0.12 75 / 0.03);
+
 	color-scheme: light dark;
 
 	/* Typography — major third (1.25) */
@@ -56,6 +61,11 @@
 		--review: oklch(72% 0.08 250);
 		--attention: oklch(68% 0.18 45);
 		--waiting: oklch(72% 0.05 250);
+
+		/* Temperature — region background tints */
+		--temperature-asking: oklch(75% 0.12 65 / 0.08);
+		--temperature-hot: oklch(70% 0.14 55 / 0.07);
+		--temperature-warm: oklch(75% 0.10 75 / 0.04);
 	}
 }
 

--- a/heimdall/src/lib/components/AppRegion.svelte
+++ b/heimdall/src/lib/components/AppRegion.svelte
@@ -21,9 +21,9 @@
 	);
 
 	let temperature = $derived.by(() => {
-		if (askingCount > 0) return 'var(--attention-tint, rgba(255, 180, 60, 0.06))';
-		if (activeCount >= 3) return 'rgba(255, 140, 50, 0.05)';
-		if (activeCount >= 1) return 'rgba(255, 160, 80, 0.03)';
+		if (askingCount > 0) return 'var(--temperature-asking)';
+		if (activeCount >= 3) return 'var(--temperature-hot)';
+		if (activeCount >= 1) return 'var(--temperature-warm)';
 		return 'transparent';
 	});
 </script>


### PR DESCRIPTION
Closes #133

## Summary

Replace hardcoded rgba values in AppRegion.svelte with OKLCH-based CSS custom properties for temperature backgrounds.

### Changes

**heimdall/src/app.css**
- Added `--temperature-asking`, `--temperature-hot`, `--temperature-warm` tokens in light mode (:root)
- Added corresponding dark mode overrides with adjusted lightness and alpha

**heimdall/src/lib/components/AppRegion.svelte**
- Replaced inline `rgba(...)` values with `var(--temperature-*)` references
- Removed unused `--attention-tint` fallback

### Token Design

| Token | Light Mode | Dark Mode |
|-------|-----------|-----------|
| --temperature-asking | oklch(82% 0.14 65 / 0.06) | oklch(75% 0.12 65 / 0.08) |
| --temperature-hot | oklch(75% 0.16 55 / 0.05) | oklch(70% 0.14 55 / 0.07) |
| --temperature-warm | oklch(80% 0.12 75 / 0.03) | oklch(75% 0.10 75 / 0.04) |

Dark mode uses lower lightness and slightly higher alpha to maintain perceptible warmth on dark backgrounds.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved consistency and maintainability of temperature indicator styling by centralizing color definitions for reuse across both light and dark themes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->