### PR TITLE
heimdall-surface: Increase touch targets to 44px minimum

### DIFF
--- a/heimdall/src/lib/components/AttentionStrip.svelte
+++ b/heimdall/src/lib/components/AttentionStrip.svelte
@@ -125,7 +125,10 @@
 	}
 
 	.action-btn {
-		display: inline-block;
+		position: relative;
+		display: inline-flex;
+		align-items: center;
+		justify-content: center;
 		font-size: var(--text-xs);
 		font-family: inherit;
 		background: var(--ground-2);
@@ -133,9 +136,17 @@
 		border: none;
 		border-radius: 4px;
 		padding: 0.25rem 0.5rem;
+		min-height: 24px;
+		min-width: 24px;
 		cursor: pointer;
 		text-decoration: none;
 		transition: background var(--duration-status) var(--ease-out-expo);
+	}
+
+	.action-btn::after {
+		content: '';
+		position: absolute;
+		inset: -12px -8px;
 	}
 
 	.action-btn:hover {


### PR DESCRIPTION
Closes #131

## Summary

Increases action button touch targets in AttentionStrip to meet WCAG 2.5.8 AA compliance (24px minimum) and best-practice touch UX (~44px) via expanded tap area.

### Changes

- Add `min-height: 24px` and `min-width: 24px` to `.action-btn` for WCAG 2.5.8 AA floor
- Add `::after` pseudo-element with `inset: -12px -8px` to expand touch target to ~44px without visual change
- Switch to `inline-flex` with centering for proper button content alignment
- Add `position: relative` to anchor the pseudo-element

### Acceptance

- Touch targets for action buttons are at least 24x24 CSS px (WCAG 2.5.8 AA)
- Visual appearance remains compact

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Refined action button styling with improved visual centering and proper content alignment for a more polished appearance.
  * Expanded the interactive clickable area to enhance user experience and accessibility, ensuring better responsiveness when users interact with buttons. Added consistent minimum dimensions for uniform button presentation across the interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->