### PR TITLE
heimdall-surface: Cover component-scoped animations in reduced motion

### DIFF
--- a/heimdall/src/lib/components/AttentionStrip.svelte
+++ b/heimdall/src/lib/components/AttentionStrip.svelte
@@ -146,4 +146,10 @@
 		opacity: 0.5;
 		cursor: not-allowed;
 	}
+
+	@media (prefers-reduced-motion: reduce) {
+		.attention-item {
+			animation: none;
+		}
+	}
 </style>

--- a/heimdall/src/lib/components/IssueMarker.svelte
+++ b/heimdall/src/lib/components/IssueMarker.svelte
@@ -223,4 +223,10 @@
 	.rotate-slow {
 		animation: rotate-slow 4s linear infinite;
 	}
+
+	@media (prefers-reduced-motion: reduce) {
+		.rotate-slow {
+			animation: none;
+		}
+	}
 </style>


### PR DESCRIPTION
Closes #132

## Summary

Add `@media (prefers-reduced-motion: reduce)` blocks to two components whose animations were not covered by the global reduced-motion rule in `app.css`:

- **AttentionStrip.svelte**: Disables `slide-in-right` entry animation on `.attention-item`
- **IssueMarker.svelte**: Disables `rotate-slow` rotation animation on `.rotate-slow`

The global rule in `app.css` handles heartbeat animations with `animation-duration: 0.01ms !important`, but these component-scoped animations benefit from explicit overrides as defense-in-depth for accessibility compliance.

### Acceptance
- No animations play when `prefers-reduced-motion: reduce` is active
- Static visual state is preserved (elements appear immediately without animation)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Added support for users with reduced motion preferences by disabling animations when requested. Slide-in and rotation animations are now skipped for users who prefer reduced motion, improving accessibility across the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->