### PR TITLE
heimdall-surface: Add focus indicators and keyboard navigation

### DIFF
--- a/heimdall/src/app.css
+++ b/heimdall/src/app.css
@@ -83,6 +83,13 @@ body {
 	-webkit-font-smoothing: antialiased;
 }
 
+/* ═══════════ Focus ═══════════ */
+
+:focus-visible {
+	outline: 2px solid var(--attention);
+	outline-offset: 2px;
+}
+
 /* ═══════════ Heartbeat Keyframes ═══════════ */
 
 @keyframes heartbeat-working {

--- a/heimdall/src/lib/components/IssueMarker.svelte
+++ b/heimdall/src/lib/components/IssueMarker.svelte
@@ -77,7 +77,8 @@
 	});
 </script>
 
-<span class="issue-marker" class:peripheral={detail === 'peripheral'} class:ambient={detail === 'ambient'} class:focused={detail === 'focused'}>
+<!-- svelte-ignore a11y_no_noninteractive_tabindex -->
+<span class="issue-marker" class:peripheral={detail === 'peripheral'} class:ambient={detail === 'ambient'} class:focused={detail === 'focused'} role="listitem" tabindex={detail === 'peripheral' ? undefined : 0}>
 	<svg
 		class="marker-svg {heartbeatClass}"
 		class:rotate-slow={isRotating}

--- a/heimdall/src/lib/components/PhaseColumn.svelte
+++ b/heimdall/src/lib/components/PhaseColumn.svelte
@@ -33,7 +33,7 @@
 	style:flex-grow={grow}
 >
 	<header class="phase-label small-caps">{PHASE_LABELS[phase]}</header>
-	<div class="issue-list">
+	<div class="issue-list" role="list">
 		{#each issues as issue (issue.number)}
 			<IssueMarker
 				{issue}


### PR DESCRIPTION
Closes #129

## Summary

Adds keyboard accessibility to the heimdall surface per audit findings F2 + F3.

### Changes

1. **Global `:focus-visible` rule** (`app.css`): `outline: 2px solid var(--attention); outline-offset: 2px` — all interactive elements get a visible focus ring on keyboard Tab
2. **IssueMarker focusable** (`IssueMarker.svelte`): `tabindex="0"` in ambient/focused detail modes (not peripheral, where markers are unlabeled dots)
3. **ARIA list semantics** (`PhaseColumn.svelte` + `IssueMarker.svelte`): `role="list"` on issue-list container, `role="listitem"` on each IssueMarker
4. **AttentionStrip action-btn**: Inherits global focus-visible style (no override needed — verified no conflicting `outline` rules)

### Verification

- `svelte-check`: 0 errors, 0 warnings
- Svelte a11y lint for `tabindex` on `role="listitem"` suppressed with `svelte-ignore` — this is a deliberate keyboard navigation pattern

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Style**
  * Enhanced keyboard focus indicators provide clearer and more consistent visual feedback when navigating the interface using keyboard controls.

* **Refactor**
  * Improved component accessibility through better semantic markup and structure, enhancing support for keyboard navigation and screen reader compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->